### PR TITLE
Select currently applied theme in the prompt

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,7 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const { applyTheme } = require("../index");
+const { getCurrentTheme, applyTheme } = require("../index");
 const inquirer = require("inquirer");
 const fuzzy = require("fuzzy");
 
@@ -13,6 +13,7 @@ const themePrompts = {
   name: "theme",
   message: "Select a theme:",
   source: searchThemes,
+  default: getCurrentTheme()
 };
 
 function searchThemes(answers, input) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,7 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const applyTheme = require("../index");
+const { applyTheme } = require("../index");
 const inquirer = require("inquirer");
 const fuzzy = require("fuzzy");
 

--- a/index.js
+++ b/index.js
@@ -3,33 +3,23 @@ const fs = require("fs");
 const path = require("path");
 const inquirer = require("inquirer");
 const { Pair } = require("yaml/types");
+const {
+  alacrittyConfigDir,
+  alacrittyConfigPath,
+  getThemeYmlPath,
+  getColors
+} = require("./utils");
 
-// alacritty.yml path
-const ymlPath = (process.env.OS === "Windows_NT")
-  ? path.resolve(
-    process.env.APPDATA,
-    "alacritty/alacritty.yml"
-  )
-  : path.resolve(
-    process.env.HOME,
-    ".config/alacritty/alacritty.yml"
-  );
 
 function updateTheme(data, theme) {
-  const themePath = path.join(__dirname, `themes/${theme}.yml`);
+  const themePath = getThemeYmlPath(theme);
   const themeFile = fs.readFileSync(themePath, "utf8");
 
   const doc = YAML.parseDocument(data);
+  const colors = getColors(doc);
 
   const themeDoc = YAML.parseDocument(themeFile);
-
-  // Find the colors key in user's alacritty.yml
-  const colors = doc.contents.items.filter((i) => i.key.value === "colors")[0];
-
-  // Find the colors key in theme.yml
-  const themeColors = themeDoc.contents.items.filter(
-    (i) => i.key.value === "colors"
-  )[0];
+  const themeColors = getColors(themeDoc);
 
   // colors key is commented out or not available
   if (!colors) {
@@ -42,14 +32,14 @@ function updateTheme(data, theme) {
 
   const newContent = String(doc);
 
-  fs.writeFile(ymlPath, newContent, "utf8", (err) => {
+  fs.writeFile(alacrittyConfigPath, newContent, "utf8", (err) => {
     if (err) throw err;
     console.log(`The theme ${theme} has been applied successfully!`);
   });
 }
 
-module.exports = function (theme) {
-  fs.readFile(ymlPath, "utf8", (err, data) => {
+function applyTheme(theme) {
+  fs.readFile(alacrittyConfigPath, "utf8", (err, data) => {
     if (err) {
       const createConfigPrompt = {
         type: "confirm",
@@ -63,16 +53,11 @@ module.exports = function (theme) {
           const templatePath = path.join(__dirname, "alacritty.yml");
           const configTemplate = fs.readFileSync(templatePath, "utf8");
 
-          const homeDir = (process.env.OS === "Windows_NT")
-            ? path.join(process.env.APPDATA, "alacritty/")
-            : path.join(process.env.HOME, ".config/alacritty/");
-
-          // If .config/alacritty folder doesn't exists, create one
-          if (!fs.existsSync(homeDir)) {
-            fs.mkdirSync(homeDir);
+          if (!fs.existsSync(alacrittyConfigDir)) {
+            fs.mkdirSync(alacrittyConfigDir);
           }
 
-          fs.writeFile(ymlPath, configTemplate, "utf8", (err) => {
+          fs.writeFile(alacrittyConfigPath, configTemplate, "utf8", (err) => {
             if (err) throw err;
             console.log("New config file created.");
             updateTheme(configTemplate, theme);
@@ -83,4 +68,8 @@ module.exports = function (theme) {
       updateTheme(data, theme);
     }
   });
+}
+
+module.exports = {
+  applyTheme: applyTheme
 };

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const {
   alacrittyConfigDir,
   alacrittyConfigPath,
   getThemeYmlPath,
-  getColors
+  getColors,
+  getThemeName
 } = require("./utils");
 
 
@@ -70,6 +71,20 @@ function applyTheme(theme) {
   });
 }
 
+function getCurrentTheme() {
+  const data = fs.readFileSync(alacrittyConfigPath, "utf-8");
+  const doc = YAML.parseDocument(data);
+  const theme = getThemeName(doc);
+  if (theme === undefined) {
+    console.warn("Unable to determine current theme");
+    return ""
+  }
+
+  console.info(`Current theme: ${theme}`);
+  return theme;
+}
+
 module.exports = {
-  applyTheme: applyTheme
+  applyTheme: applyTheme,
+  getCurrentTheme: getCurrentTheme
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "fuzzy": "^0.1.3",
     "inquirer": "^7.2.0",
-    "inquirer-autocomplete-prompt": "^1.1.0",
+    "inquirer-autocomplete-prompt": "^1.2.0",
     "yaml": "^1.10.0"
   },
   "preferGlobal": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 dependencies:
   fuzzy: 0.1.3
   inquirer: 7.2.0
-  inquirer-autocomplete-prompt: 1.1.0_inquirer@7.2.0
+  inquirer-autocomplete-prompt: 1.2.0_inquirer@7.2.0
   yaml: 1.10.0
 lockfileVersion: 5.1
 packages:
@@ -126,7 +126,7 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  /inquirer-autocomplete-prompt/1.1.0_inquirer@7.2.0:
+  /inquirer-autocomplete-prompt/1.2.0_inquirer@7.2.0:
     dependencies:
       ansi-escapes: 4.3.1
       chalk: 4.1.0
@@ -140,7 +140,7 @@ packages:
     peerDependencies:
       inquirer: ^5.0.0 || ^6.0.0 || ^7.0.0
     resolution:
-      integrity: sha512-mrSeUSFGnTSid/DCKG+E+IcN4MaOnT2bW7NuSagZAguD4k3hZ0UladdYNP4EstZOwgeqv0C3M1zYa1QIIf0Oyg==
+      integrity: sha512-t8A0gFq0mOKGz8wmGBPh+M/AC8KSMMcn7dnHXzLWyKvLiRYWswQ6rg7d938hoR5tVP1GpHVmHOR6YP8G5dYhhQ==
   /inquirer/7.2.0:
     dependencies:
       ansi-escapes: 4.3.1
@@ -299,5 +299,5 @@ packages:
 specifiers:
   fuzzy: ^0.1.3
   inquirer: ^7.2.0
-  inquirer-autocomplete-prompt: ^1.1.0
+  inquirer-autocomplete-prompt: ^1.2.0
   yaml: ^1.10.0

--- a/themes/3024.dark.yml
+++ b/themes/3024.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: 3024 (dark)
+  name: 3024.dark
   author: Chris Kempson
   primary:
     background: "#090300"

--- a/themes/3024.light.yml
+++ b/themes/3024.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: 3024 (light)
+  name: 3024.light
   author: Chris Kempson
   primary:
     background: "#f7f7f7"

--- a/themes/Afterglow.yml
+++ b/themes/Afterglow.yml
@@ -1,48 +1,39 @@
 colors:
-  # Default colors
   primary:
-    background: '#2c2c2c'
-    foreground: '#d6d6d6'
-
-    dim_foreground:    '#dbdbdb'
-    bright_foreground: '#d9d9d9'
-    dim_background:    '#202020' # not sure
-    bright_background: '#3a3a3a' # not sure
-
-  # Cursor colors
+    background: "#2c2c2c"
+    foreground: "#d6d6d6"
+    dim_foreground: "#dbdbdb"
+    bright_foreground: "#d9d9d9"
+    dim_background: "#202020"
+    bright_background: "#3a3a3a"
   cursor:
-    text:   '#2c2c2c'
-    cursor: '#d9d9d9'
-
-  # Normal colors
+    text: "#2c2c2c"
+    cursor: "#d9d9d9"
   normal:
-    black:   '#1c1c1c'
-    red:     '#bc5653'
-    green:   '#909d63'
-    yellow:  '#ebc17a'
-    blue:    '#7eaac7'
-    magenta: '#aa6292'
-    cyan:    '#86d3ce'
-    white:   '#cacaca'
-
-  # Bright colors
+    black: "#1c1c1c"
+    red: "#bc5653"
+    green: "#909d63"
+    yellow: "#ebc17a"
+    blue: "#7eaac7"
+    magenta: "#aa6292"
+    cyan: "#86d3ce"
+    white: "#cacaca"
   bright:
-    black:   '#636363'
-    red:     '#bc5653'
-    green:   '#909d63'
-    yellow:  '#ebc17a'
-    blue:    '#7eaac7'
-    magenta: '#aa6292'
-    cyan:    '#86d3ce'
-    white:   '#f7f7f7'
-
-  # Dim colors
+    black: "#636363"
+    red: "#bc5653"
+    green: "#909d63"
+    yellow: "#ebc17a"
+    blue: "#7eaac7"
+    magenta: "#aa6292"
+    cyan: "#86d3ce"
+    white: "#f7f7f7"
   dim:
-    black:   '#232323'
-    red:     '#74423f'
-    green:   '#5e6547'
-    yellow:  '#8b7653'
-    blue:    '#556b79'
-    magenta: '#6e4962'
-    cyan:    '#5c8482'
-    white:   '#828282'
+    black: "#232323"
+    red: "#74423f"
+    green: "#5e6547"
+    yellow: "#8b7653"
+    blue: "#556b79"
+    magenta: "#6e4962"
+    cyan: "#5c8482"
+    white: "#828282"
+  name: Afterglow

--- a/themes/Argonaut.yml
+++ b/themes/Argonaut.yml
@@ -1,32 +1,26 @@
 colors:
-  # Default colors
   primary:
-    background: '#292C3E'
-    foreground: '#EBEBEB'
-
-  # Cursor colors
+    background: "#292C3E"
+    foreground: "#EBEBEB"
   cursor:
-   text: '#FF261E'
-   cursor: '#FF261E'
-
-  # Normal colors
+    text: "#FF261E"
+    cursor: "#FF261E"
   normal:
-    black:   '#0d0d0d'
-    red:     '#FF301B'
-    green:   '#A0E521'
-    yellow:  '#FFC620'
-    blue:    '#1BA6FA'
-    magenta: '#8763B8'
-    cyan:    '#21DEEF'
-    white:   '#EBEBEB'
-
-  # Bright colors
+    black: "#0d0d0d"
+    red: "#FF301B"
+    green: "#A0E521"
+    yellow: "#FFC620"
+    blue: "#1BA6FA"
+    magenta: "#8763B8"
+    cyan: "#21DEEF"
+    white: "#EBEBEB"
   bright:
-    black:   '#6D7070'
-    red:     '#FF4352'
-    green:   '#B8E466'
-    yellow:  '#FFD750'
-    blue:    '#1BA6FA'
-    magenta: '#A578EA'
-    cyan:    '#73FBF1'
-    white:   '#FEFEF8'
+    black: "#6D7070"
+    red: "#FF4352"
+    green: "#B8E466"
+    yellow: "#FFD750"
+    blue: "#1BA6FA"
+    magenta: "#A578EA"
+    cyan: "#73FBF1"
+    white: "#FEFEF8"
+  name: Argonaut

--- a/themes/Ashes.dark.yml
+++ b/themes/Ashes.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Ashes (dark)
+  name: Ashes.dark
   author: Chris Kempson
   primary:
     background: "#1c2023"

--- a/themes/Ashes.light.yml
+++ b/themes/Ashes.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Ashes (light)
+  name: Ashes.light
   author: Chris Kempson
   primary:
     background: "#f3f4f5"

--- a/themes/Astromouse.yml
+++ b/themes/Astromouse.yml
@@ -1,5 +1,5 @@
 colors:
-  name: astromouse
+  name: Astromouse
   author: ""
   primary:
     background: "#000000"

--- a/themes/Atelierdune.dark.yml
+++ b/themes/Atelierdune.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Atelierdune (dark)
+  name: Atelierdune.dark
   author: Chris Kempson
   primary:
     background: "#20201d"

--- a/themes/Atelierdune.light.yml
+++ b/themes/Atelierdune.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Atelierdune (light)
+  name: Atelierdune.light
   author: Chris Kempson
   primary:
     background: "#fefbec"

--- a/themes/Atelierforest.dark.yml
+++ b/themes/Atelierforest.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Atelierforest (dark)
+  name: Atelierforest.dark
   author: Chris Kempson
   primary:
     background: "#1b1918"

--- a/themes/Atelierforest.light.yml
+++ b/themes/Atelierforest.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Atelierforest (light)
+  name: Atelierforest.light
   author: Chris Kempson
   primary:
     background: "#f1efee"

--- a/themes/Atelierheath.dark.yml
+++ b/themes/Atelierheath.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Atelierheath (dark)
+  name: Atelierheath.dark
   author: Chris Kempson
   primary:
     background: "#1b181b"

--- a/themes/Atelierheath.light.yml
+++ b/themes/Atelierheath.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Atelierheath (light)
+  name: Atelierheath.light
   author: Chris Kempson
   primary:
     background: "#f7f3f7"

--- a/themes/Atelierlakeside.dark.yml
+++ b/themes/Atelierlakeside.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Atelierlakeside (dark)
+  name: Atelierlakeside.dark
   author: Chris Kempson
   primary:
     background: "#161b1d"

--- a/themes/Atelierlakeside.light.yml
+++ b/themes/Atelierlakeside.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Atelierlakeside (light)
+  name: Atelierlakeside.light
   author: Chris Kempson
   primary:
     background: "#ebf8ff"

--- a/themes/Atelierseaside.dark.yml
+++ b/themes/Atelierseaside.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Atelierseaside (dark)
+  name: Atelierseaside.dark
   author: Chris Kempson
   primary:
     background: "#131513"

--- a/themes/Atelierseaside.light.yml
+++ b/themes/Atelierseaside.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Atelierseaside (light)
+  name: Atelierseaside.light
   author: Chris Kempson
   primary:
     background: "#f0fff0"

--- a/themes/Ayu-Dark.yml
+++ b/themes/Ayu-Dark.yml
@@ -1,28 +1,23 @@
-# Colors (Ayu Dark)
 colors:
-  # Default colors
   primary:
-    background: '#0A0E14'
-    foreground: '#B3B1AD'
-
-  # Normal colors
+    background: "#0A0E14"
+    foreground: "#B3B1AD"
   normal:
-    black: '#01060E'
-    red: '#EA6C73'
-    green: '#91B362'
-    yellow: '#F9AF4F'
-    blue: '#53BDFA'
-    magenta: '#FAE994'
-    cyan: '#90E1C6'
-    white: '#C7C7C7'
-
-  # Bright colors
+    black: "#01060E"
+    red: "#EA6C73"
+    green: "#91B362"
+    yellow: "#F9AF4F"
+    blue: "#53BDFA"
+    magenta: "#FAE994"
+    cyan: "#90E1C6"
+    white: "#C7C7C7"
   bright:
-    black: '#686868'
-    red: '#F07178'
-    green: '#C2D94C'
-    yellow: '#FFB454'
-    blue: '#59C2FF'
-    magenta: '#FFEE99'
-    cyan: '#95E6CB'
-    white: '#FFFFFF'
+    black: "#686868"
+    red: "#F07178"
+    green: "#C2D94C"
+    yellow: "#FFB454"
+    blue: "#59C2FF"
+    magenta: "#FFEE99"
+    cyan: "#95E6CB"
+    white: "#FFFFFF"
+  name: Ayu-Dark

--- a/themes/Ayu-Mirage.yml
+++ b/themes/Ayu-Mirage.yml
@@ -1,28 +1,23 @@
-# Colors (Ayu Mirage)
 colors:
-  # Default colors
   primary:
-    background: '#202734'
-    foreground: '#CBCCC6'
-
-  # Normal colors
+    background: "#202734"
+    foreground: "#CBCCC6"
   normal:
-    black: '#191E2A'
-    red: '#FF3333'
-    green: '#BAE67E'
-    yellow: '#FFA759'
-    blue: '#73D0FF'
-    magenta: '#FFD580'
-    cyan: '#95E6CB'
-    white: '#C7C7C7'
-
-  # Bright colors
+    black: "#191E2A"
+    red: "#FF3333"
+    green: "#BAE67E"
+    yellow: "#FFA759"
+    blue: "#73D0FF"
+    magenta: "#FFD580"
+    cyan: "#95E6CB"
+    white: "#C7C7C7"
   bright:
-    black: '#686868'
-    red: '#F27983'
-    green: '#A6CC70'
-    yellow: '#FFCC66'
-    blue: '#5CCFE6'
-    magenta: '#FFEE99'
-    cyan: '#95E6CB'
-    white: '#FFFFFF'
+    black: "#686868"
+    red: "#F27983"
+    green: "#A6CC70"
+    yellow: "#FFCC66"
+    blue: "#5CCFE6"
+    magenta: "#FFEE99"
+    cyan: "#95E6CB"
+    white: "#FFFFFF"
+  name: Ayu-Mirage

--- a/themes/Base16-Default-Dark.yml
+++ b/themes/Base16-Default-Dark.yml
@@ -1,33 +1,26 @@
-# Colors (Base16 Default Dark)
 colors:
-  # Default colors
   primary:
-    background: '#181818'
-    foreground: '#d8d8d8'
-
-  # Colors the cursor will use if `custom_cursor_colors` is true
+    background: "#181818"
+    foreground: "#d8d8d8"
   cursor:
-    text: '#d8d8d8'
-    cursor: '#d8d8d8'
-
-  # Normal colors
+    text: "#d8d8d8"
+    cursor: "#d8d8d8"
   normal:
-    black:   '#181818'
-    red:     '#ab4642'
-    green:   '#a1b56c'
-    yellow:  '#f7ca88'
-    blue:    '#7cafc2'
-    magenta: '#ba8baf'
-    cyan:    '#86c1b9'
-    white:   '#d8d8d8'
-
-  # Bright colors
+    black: "#181818"
+    red: "#ab4642"
+    green: "#a1b56c"
+    yellow: "#f7ca88"
+    blue: "#7cafc2"
+    magenta: "#ba8baf"
+    cyan: "#86c1b9"
+    white: "#d8d8d8"
   bright:
-    black:   '#585858'
-    red:     '#ab4642'
-    green:   '#a1b56c'
-    yellow:  '#f7ca88'
-    blue:    '#7cafc2'
-    magenta: '#ba8baf'
-    cyan:    '#86c1b9'
-    white:   '#f8f8f8'
+    black: "#585858"
+    red: "#ab4642"
+    green: "#a1b56c"
+    yellow: "#f7ca88"
+    blue: "#7cafc2"
+    magenta: "#ba8baf"
+    cyan: "#86c1b9"
+    white: "#f8f8f8"
+  name: Base16-Default-Dark

--- a/themes/Baskerville - Count Von Count.yml
+++ b/themes/Baskerville - Count Von Count.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Count Von Count
+  name: Baskerville - Count Von Count
   author: Baskerville
   primary:
     background: "#000000"

--- a/themes/Baskerville - Eldorado dark.yml
+++ b/themes/Baskerville - Eldorado dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Eldorado dark
+  name: Baskerville - Eldorado dark
   author: Baskerville
   primary:
     background: "#292929"

--- a/themes/Baskerville - FarSide.yml
+++ b/themes/Baskerville - FarSide.yml
@@ -1,5 +1,5 @@
 colors:
-  name: FarSide
+  name: Baskerville - FarSide
   author: Baskerville
   primary:
     background: "#000000"

--- a/themes/Baskerville - ivory dark.yml
+++ b/themes/Baskerville - ivory dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Ivory Dark
+  name: Baskerville - ivory dark
   author: Baskerville
   primary:
     background: "#2d2c28"

--- a/themes/Baskerville - lost woods.yml
+++ b/themes/Baskerville - lost woods.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Lost Woods
+  name: Baskerville - lost woods
   author: Baskerville
   primary:
     background: "#000000"

--- a/themes/Baskerville-ivorylight.yml
+++ b/themes/Baskerville-ivorylight.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Ivory Light
+  name: Baskerville-ivorylight
   author: Baskerville
   primary:
     background: "#fef9ec"

--- a/themes/Bespin.dark.yml
+++ b/themes/Bespin.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Bespin (dark)
+  name: Bespin.dark
   author: Chris Kempson
   primary:
     background: "#28211c"

--- a/themes/Bespin.light.yml
+++ b/themes/Bespin.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Bespin (light)
+  name: Bespin.light
   author: Chris Kempson
   primary:
     background: "#baae9e"

--- a/themes/Blood-Moon.yml
+++ b/themes/Blood-Moon.yml
@@ -1,28 +1,23 @@
-# Colors (Blood Moon)
 colors:
-  # Default colors
   primary:
-    background: '#10100E'
-    foreground: '#C6C6C4'
-
-  # Normal colors
+    background: "#10100E"
+    foreground: "#C6C6C4"
   normal:
-    black:   '#10100E'
-    red:     '#C40233'
-    green:   '#009F6B'
-    yellow:  '#FFD700'
-    blue:    '#0087BD'
-    magenta: '#9A4EAE'
-    cyan:    '#20B2AA'
-    white:   '#C6C6C4'
-
-  # Bright colors
+    black: "#10100E"
+    red: "#C40233"
+    green: "#009F6B"
+    yellow: "#FFD700"
+    blue: "#0087BD"
+    magenta: "#9A4EAE"
+    cyan: "#20B2AA"
+    white: "#C6C6C4"
   bright:
-    black:   '#696969'
-    red:     '#FF2400'
-    green:   '#03C03C'
-    yellow:  '#FDFF00'
-    blue:    '#007FFF'
-    magenta: '#FF1493'
-    cyan:    '#00CCCC'
-    white:   '#FFFAFA'
+    black: "#696969"
+    red: "#FF2400"
+    green: "#03C03C"
+    yellow: "#FDFF00"
+    blue: "#007FFF"
+    magenta: "#FF1493"
+    cyan: "#00CCCC"
+    white: "#FFFAFA"
+  name: Blood-Moon

--- a/themes/Breeze.yml
+++ b/themes/Breeze.yml
@@ -1,44 +1,36 @@
-# KDE Breeze (Ported from Konsole)
 colors:
-  # Default colors
   primary:
-    background: '#232627'
-    foreground: '#fcfcfc'
-
-    dim_foreground: '#eff0f1'
-    bright_foreground: '#ffffff'
-    dim_background: '#31363b'
-    bright_background: '#000000'
-
-  # Normal colors
+    background: "#232627"
+    foreground: "#fcfcfc"
+    dim_foreground: "#eff0f1"
+    bright_foreground: "#ffffff"
+    dim_background: "#31363b"
+    bright_background: "#000000"
   normal:
-    black: '#232627'
-    red: '#ed1515'
-    green: '#11d116'
-    yellow: '#f67400'
-    blue: '#1d99f3'
-    magenta: '#9b59b6'
-    cyan: '#1abc9c'
-    white: '#fcfcfc'
-
-  # Bright colors
+    black: "#232627"
+    red: "#ed1515"
+    green: "#11d116"
+    yellow: "#f67400"
+    blue: "#1d99f3"
+    magenta: "#9b59b6"
+    cyan: "#1abc9c"
+    white: "#fcfcfc"
   bright:
-    black: '#7f8c8d'
-    red: '#c0392b'
-    green: '#1cdc9a'
-    yellow: '#fdbc4b'
-    blue: '#3daee9'
-    magenta: '#8e44ad'
-    cyan: '#16a085'
-    white: '#ffffff'
-
-  # Dim colors
+    black: "#7f8c8d"
+    red: "#c0392b"
+    green: "#1cdc9a"
+    yellow: "#fdbc4b"
+    blue: "#3daee9"
+    magenta: "#8e44ad"
+    cyan: "#16a085"
+    white: "#ffffff"
   dim:
-    black: '#31363b'
-    red: '#783228'
-    green: '#17a262'
-    yellow: '#b65619'
-    blue: '#1b668f'
-    magenta: '#614a73'
-    cyan: '#186c60'
-    white: '#63686d'
+    black: "#31363b"
+    red: "#783228"
+    green: "#17a262"
+    yellow: "#b65619"
+    blue: "#1b668f"
+    magenta: "#614a73"
+    cyan: "#186c60"
+    white: "#63686d"
+  name: Breeze

--- a/themes/Brewer.dark.yml
+++ b/themes/Brewer.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Brewer (dark)
+  name: Brewer.dark
   author: Chris Kempson
   primary:
     background: "#0c0d0e"

--- a/themes/Brewer.light.yml
+++ b/themes/Brewer.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Brewer (light)
+  name: Brewer.light
   author: Chris Kempson
   primary:
     background: "#fcfdfe"

--- a/themes/Campbell.yml
+++ b/themes/Campbell.yml
@@ -1,28 +1,23 @@
-# Campbell (Windows 10 default)
 colors:
-  # Default colors
   primary:
-    background: '#0c0c0c'
-    foreground: '#cccccc'
-
-  # Normal colors
+    background: "#0c0c0c"
+    foreground: "#cccccc"
   normal:
-    black:      '#0c0c0c'
-    red:        '#c50f1f'
-    green:      '#13a10e'
-    yellow:     '#c19c00'
-    blue:       '#0037da'
-    magenta:    '#881798'
-    cyan:       '#3a96dd'
-    white:      '#cccccc'
-
-  # Bright colors
+    black: "#0c0c0c"
+    red: "#c50f1f"
+    green: "#13a10e"
+    yellow: "#c19c00"
+    blue: "#0037da"
+    magenta: "#881798"
+    cyan: "#3a96dd"
+    white: "#cccccc"
   bright:
-    black:      '#767676'
-    red:        '#e74856'
-    green:      '#16c60c'
-    yellow:     '#f9f1a5'
-    blue:       '#3b78ff'
-    magenta:    '#b4009e'
-    cyan:       '#61d6d6'
-    white:      '#f2f2f2'
+    black: "#767676"
+    red: "#e74856"
+    green: "#16c60c"
+    yellow: "#f9f1a5"
+    blue: "#3b78ff"
+    magenta: "#b4009e"
+    cyan: "#61d6d6"
+    white: "#f2f2f2"
+  name: Campbell

--- a/themes/Chalk.dark.yml
+++ b/themes/Chalk.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Chalk (dark)
+  name: Chalk.dark
   author: Chris Kempson
   primary:
     background: "#151515"

--- a/themes/Chalk.light.yml
+++ b/themes/Chalk.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Chalk (light)
+  name: Chalk.light
   author: Chris Kempson
   primary:
     background: "#f5f5f5"

--- a/themes/Cobalt-2.yml
+++ b/themes/Cobalt-2.yml
@@ -1,33 +1,29 @@
-# Colors (Cobalt 2)
 colors:
   cursor:
-    text: '#fefff2'
-    cursor: '#f0cc09'
-
+    text: "#fefff2"
+    cursor: "#f0cc09"
   selection:
-    text: '#b5b5b5'
-    background: '#18354f'
-
+    text: "#b5b5b5"
+    background: "#18354f"
   primary:
-    background: '#132738'
-    foreground: '#ffffff'
-
+    background: "#132738"
+    foreground: "#ffffff"
   normal:
-    black:   '#000000'
-    red:     '#ff0000'
-    green:   '#38de21'
-    yellow:  '#ffe50a'
-    blue:    '#1460d2'
-    magenta: '#ff005d'
-    cyan:    '#00bbbb'
-    white:   '#bbbbbb'
-
+    black: "#000000"
+    red: "#ff0000"
+    green: "#38de21"
+    yellow: "#ffe50a"
+    blue: "#1460d2"
+    magenta: "#ff005d"
+    cyan: "#00bbbb"
+    white: "#bbbbbb"
   bright:
-    black:   '#555555'
-    red:     '#f40e17'
-    green:   '#3bd01d'
-    yellow:  '#edc809'
-    blue:    '#5555ff'
-    magenta: '#ff55ff'
-    cyan:    '#6ae3fa'
-    white:   '#ffffff'
+    black: "#555555"
+    red: "#f40e17"
+    green: "#3bd01d"
+    yellow: "#edc809"
+    blue: "#5555ff"
+    magenta: "#ff55ff"
+    cyan: "#6ae3fa"
+    white: "#ffffff"
+  name: Cobalt-2

--- a/themes/Codeschool.dark.yml
+++ b/themes/Codeschool.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Codeschool (dark)
+  name: Codeschool.dark
   author: Chris Kempson
   primary:
     background: "#232c31"

--- a/themes/Codeschool.light.yml
+++ b/themes/Codeschool.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Codeschool (light)
+  name: Codeschool.light
   author: Chris Kempson
   primary:
     background: "#b5d8f6"

--- a/themes/Colorfulcolors.yml
+++ b/themes/Colorfulcolors.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Colorful Colors
+  name: Colorfulcolors
   author: ""
   primary:
     background: "#000000"

--- a/themes/DOOMICIDE darkocean.yml
+++ b/themes/DOOMICIDE darkocean.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Dark Ocean
+  name: DOOMICIDE darkocean
   author: DOOMICIDE
   primary:
     background: "#000000"

--- a/themes/Darkside.yml
+++ b/themes/Darkside.yml
@@ -1,27 +1,23 @@
-# Colors (Darkside)
 colors:
   primary:
-    background: '#222324'
-    foreground: '#BABABA'
-
-  # Normal colors
+    background: "#222324"
+    foreground: "#BABABA"
   normal:
-    black:    '#000000'
-    red:      '#E8341C'
-    green:    '#68C256'
-    yellow:   '#F2D42C'
-    blue:     '#1C98E8'
-    magenta:  '#8E69C9'
-    cyan:     '#1C98E8'
-    white:    '#BABABA'
-
-  # Bright colors
+    black: "#000000"
+    red: "#E8341C"
+    green: "#68C256"
+    yellow: "#F2D42C"
+    blue: "#1C98E8"
+    magenta: "#8E69C9"
+    cyan: "#1C98E8"
+    white: "#BABABA"
   bright:
-    black:    '#666666'
-    red:      '#E05A4F'
-    green:    '#77B869'
-    yellow:   '#EFD64B'
-    blue:     '#387CD3'
-    magenta:  '#957BBE'
-    cyan:     '#3D97E2'
-    white:    '#BABABA'
+    black: "#666666"
+    red: "#E05A4F"
+    green: "#77B869"
+    yellow: "#EFD64B"
+    blue: "#387CD3"
+    magenta: "#957BBE"
+    cyan: "#3D97E2"
+    white: "#BABABA"
+  name: Darkside

--- a/themes/Darktooth.yml
+++ b/themes/Darktooth.yml
@@ -1,40 +1,32 @@
-# Colors (Darktooth)
 colors:
-
-  # Default colors
   primary:
-    background: '#282828'
-    foreground: '#fdf4c1'
-
-  # Normal colors
+    background: "#282828"
+    foreground: "#fdf4c1"
   normal:
-    black:   '#282828'
-    red:     '#9d0006'
-    green:   '#79740e'
-    yellow:  '#b57614'
-    blue:    '#076678'
-    magenta: '#8f3f71'
-    cyan:    '#00a7af'
-    white:   '#fdf4c1'
-
-  # Bright colors
+    black: "#282828"
+    red: "#9d0006"
+    green: "#79740e"
+    yellow: "#b57614"
+    blue: "#076678"
+    magenta: "#8f3f71"
+    cyan: "#00a7af"
+    white: "#fdf4c1"
   bright:
-    black:   '#32302f'
-    red:     '#fb4933'
-    green:   '#b8bb26'
-    yellow:  '#fabd2f'
-    blue:    '#83a598'
-    magenta: '#d3869b'
-    cyan:    '#3fd7e5'
-    white:   '#ffffc8'
-
-  # Dim colors (Optional)
+    black: "#32302f"
+    red: "#fb4933"
+    green: "#b8bb26"
+    yellow: "#fabd2f"
+    blue: "#83a598"
+    magenta: "#d3869b"
+    cyan: "#3fd7e5"
+    white: "#ffffc8"
   dim:
-    black:   '#1d2021'
-    red:     '#421e1e'
-    green:   '#232b0f'
-    yellow:  '#4d3b27'
-    blue:    '#2b3c44'
-    magenta: '#4e3d45'
-    cyan:    '#205161'
-    white:   '#f4e8ba'
+    black: "#1d2021"
+    red: "#421e1e"
+    green: "#232b0f"
+    yellow: "#4d3b27"
+    blue: "#2b3c44"
+    magenta: "#4e3d45"
+    cyan: "#205161"
+    white: "#f4e8ba"
+  name: Darktooth

--- a/themes/Default.dark.yml
+++ b/themes/Default.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Default (dark)
+  name: Default.dark
   author: Chris Kempson
   primary:
     background: "#151515"

--- a/themes/Default.light.yml
+++ b/themes/Default.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Default (light)
+  name: Default.light
   author: Chris Kempson
   primary:
     background: "#f5f5f5"

--- a/themes/Dkeg - canvasedpastel.yml
+++ b/themes/Dkeg - canvasedpastel.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Canvased Pastel
+  name: Dkeg - canvasedpastel
   author: dkeg
   primary:
     background: "#170f0d"

--- a/themes/Dkeg - catchmeifyoucan.yml
+++ b/themes/Dkeg - catchmeifyoucan.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Catch Me If You Can
+  name: Dkeg - catchmeifyoucan
   author: dkeg
   primary:
     background: "#170f0d"

--- a/themes/Dkeg - citystreets.yml
+++ b/themes/Dkeg - citystreets.yml
@@ -1,5 +1,5 @@
 colors:
-  name: City Streets
+  name: Dkeg - citystreets
   author: dkeg
   primary:
     background: "#000000"

--- a/themes/Dkeg - colorstar.yml
+++ b/themes/Dkeg - colorstar.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Color Star
+  name: Dkeg - colorstar
   author: dkeg
   primary:
     background: "#000000"

--- a/themes/Dkeg - panels.yml
+++ b/themes/Dkeg - panels.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Panels
+  name: Dkeg - panels
   author: dkeg
   primary:
     background: "#000000"

--- a/themes/Dkeg - redphoenix.yml
+++ b/themes/Dkeg - redphoenix.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Red Phoenix
+  name: Dkeg - redphoenix
   author: dkeg
   primary:
     background: "#111111"

--- a/themes/Dkeg - teva.yml
+++ b/themes/Dkeg - teva.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Teva
+  name: Dkeg - teva
   author: dkeg
   primary:
     background: "#170f0d"

--- a/themes/Dkeg - unsiftedwheat.yml
+++ b/themes/Dkeg - unsiftedwheat.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Unsifted Wheat
+  name: Dkeg - unsiftedwheat
   author: dkeg
   primary:
     background: "#111111"

--- a/themes/Dkeg - vwbug.yml
+++ b/themes/Dkeg - vwbug.yml
@@ -1,5 +1,5 @@
 colors:
-  name: VWbug
+  name: Dkeg - vwbug
   author: dkeg
   primary:
     background: "#170f0d"

--- a/themes/Dracula.yml
+++ b/themes/Dracula.yml
@@ -1,28 +1,23 @@
-# Colors (Dracula)
 colors:
-  # Default colors
   primary:
-    background: '#282a36'
-    foreground: '#f8f8f2'
-
-  # Normal colors
+    background: "#282a36"
+    foreground: "#f8f8f2"
   normal:
-    black:   '#000000'
-    red:     '#ff5555'
-    green:   '#50fa7b'
-    yellow:  '#f1fa8c'
-    blue:    '#caa9fa'
-    magenta: '#ff79c6'
-    cyan:    '#8be9fd'
-    white:   '#bfbfbf'
-
-  # Bright colors
+    black: "#000000"
+    red: "#ff5555"
+    green: "#50fa7b"
+    yellow: "#f1fa8c"
+    blue: "#caa9fa"
+    magenta: "#ff79c6"
+    cyan: "#8be9fd"
+    white: "#bfbfbf"
   bright:
-    black:   '#575b70'
-    red:     '#ff6e67'
-    green:   '#5af78e'
-    yellow:  '#f4f99d'
-    blue:    '#caa9fa'
-    magenta: '#ff92d0'
-    cyan:    '#9aedfe'
-    white:   '#e6e6e6'
+    black: "#575b70"
+    red: "#ff6e67"
+    green: "#5af78e"
+    yellow: "#f4f99d"
+    blue: "#caa9fa"
+    magenta: "#ff92d0"
+    cyan: "#9aedfe"
+    white: "#e6e6e6"
+  name: Dracula

--- a/themes/Dwmrob.yml
+++ b/themes/Dwmrob.yml
@@ -1,5 +1,5 @@
 colors:
-  name: DWM rob
+  name: Dwmrob
   author: ""
   primary:
     background: "#000000"

--- a/themes/Eighties.dark.yml
+++ b/themes/Eighties.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Eighties (dark)
+  name: Eighties.dark
   author: Chris Kempson
   primary:
     background: "#2d2d2d"

--- a/themes/Eighties.light.yml
+++ b/themes/Eighties.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Eighties (light)
+  name: Eighties.light
   author: Chris Kempson
   primary:
     background: "#f2f0ec"

--- a/themes/Embers.dark.yml
+++ b/themes/Embers.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Embers (dark)
+  name: Embers.dark
   author: Chris Kempson
   primary:
     background: "#16130f"

--- a/themes/Embers.light.yml
+++ b/themes/Embers.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Embers (light)
+  name: Embers.light
   author: Chris Kempson
   primary:
     background: "#dbd6d1"

--- a/themes/Gjm.yml
+++ b/themes/Gjm.yml
@@ -1,5 +1,5 @@
 colors:
-  name: GJM
+  name: Gjm
   author: ""
   primary:
     background: "#1c1c1c"

--- a/themes/Google.dark.yml
+++ b/themes/Google.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Google (dark)
+  name: Google.dark
   author: Chris Kempson
   primary:
     background: "#1d1f21"

--- a/themes/Google.light.yml
+++ b/themes/Google.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Google (light)
+  name: Google.light
   author: Chris Kempson
   primary:
     background: "#ffffff"

--- a/themes/Grayscale.dark.yml
+++ b/themes/Grayscale.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Grayscale (dark)
+  name: Grayscale.dark
   author: Chris Kempson
   primary:
     background: "#101010"

--- a/themes/Grayscale.light.yml
+++ b/themes/Grayscale.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Grayscale (light)
+  name: Grayscale.light
   author: Chris Kempson
   primary:
     background: "#f7f7f7"

--- a/themes/Greenscreen.dark.yml
+++ b/themes/Greenscreen.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Greenscreen (dark)
+  name: Greenscreen.dark
   author: Chris Kempson
   primary:
     background: "#001100"

--- a/themes/Greenscreen.light.yml
+++ b/themes/Greenscreen.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Greenscreen (light)
+  name: Greenscreen.light
   author: Chris Kempson
   primary:
     background: "#00ff00"

--- a/themes/Grubox-Light.yml
+++ b/themes/Grubox-Light.yml
@@ -1,30 +1,23 @@
-# Colors (Gruvbox light)
 colors:
-  # Default colors
   primary:
-    # hard contrast: background = '#f9f5d7'
-    background: '#fbf1c7'
-    # soft contrast: background = '#f2e5bc'
-    foreground: '#3c3836'
-
-  # Normal colors
+    background: "#fbf1c7"
+    foreground: "#3c3836"
   normal:
-    black:   '#fbf1c7'
-    red:     '#cc241d'
-    green:   '#98971a'
-    yellow:  '#d79921'
-    blue:    '#458588'
-    magenta: '#b16286'
-    cyan:    '#689d6a'
-    white:   '#7c6f64'
-
-  # Bright colors
+    black: "#fbf1c7"
+    red: "#cc241d"
+    green: "#98971a"
+    yellow: "#d79921"
+    blue: "#458588"
+    magenta: "#b16286"
+    cyan: "#689d6a"
+    white: "#7c6f64"
   bright:
-    black:   '#928374'
-    red:     '#9d0006'
-    green:   '#79740e'
-    yellow:  '#b57614'
-    blue:    '#076678'
-    magenta: '#8f3f71'
-    cyan:    '#427b58'
-    white:   '#3c3836'
+    black: "#928374"
+    red: "#9d0006"
+    green: "#79740e"
+    yellow: "#b57614"
+    blue: "#076678"
+    magenta: "#8f3f71"
+    cyan: "#427b58"
+    white: "#3c3836"
+  name: Grubox-Light

--- a/themes/Gruvbox-Dark.yml
+++ b/themes/Gruvbox-Dark.yml
@@ -1,30 +1,23 @@
-# Colors (Gruvbox dark)
 colors:
-  # Default colors
   primary:
-    # hard contrast: background = '#1d2021'
-    background: '#282828'
-    # soft contrast: background = '#32302f'
-    foreground: '#ebdbb2'
-
-  # Normal colors
+    background: "#282828"
+    foreground: "#ebdbb2"
   normal:
-    black:   '#282828'
-    red:     '#cc241d'
-    green:   '#98971a'
-    yellow:  '#d79921'
-    blue:    '#458588'
-    magenta: '#b16286'
-    cyan:    '#689d6a'
-    white:   '#a89984'
-
-  # Bright colors
+    black: "#282828"
+    red: "#cc241d"
+    green: "#98971a"
+    yellow: "#d79921"
+    blue: "#458588"
+    magenta: "#b16286"
+    cyan: "#689d6a"
+    white: "#a89984"
   bright:
-    black:   '#928374'
-    red:     '#fb4934'
-    green:   '#b8bb26'
-    yellow:  '#fabd2f'
-    blue:    '#83a598'
-    magenta: '#d3869b'
-    cyan:    '#8ec07c'
-    white:   '#ebdbb2'
+    black: "#928374"
+    red: "#fb4934"
+    green: "#b8bb26"
+    yellow: "#fabd2f"
+    blue: "#83a598"
+    magenta: "#d3869b"
+    cyan: "#8ec07c"
+    white: "#ebdbb2"
+  name: Gruvbox-Dark

--- a/themes/Gslob nature-suede.yml
+++ b/themes/Gslob nature-suede.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Nature Suede
+  name: Gslob nature-suede
   author: Gslob
   primary:
     background: "#170f0d"

--- a/themes/Gutterslob - aikofog.yml
+++ b/themes/Gutterslob - aikofog.yml
@@ -1,5 +1,5 @@
 colors:
-  name: aikofog
+  name: Gutterslob - aikofog
   author: Gutterslob
   primary:
     background: "#f1eee9"

--- a/themes/Gutterslob - lumifoo.yml
+++ b/themes/Gutterslob - lumifoo.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Lumifoo
+  name: Gutterslob - lumifoo
   author: Gutterslob
   primary:
     background: "#1e2021"

--- a/themes/Gutterslob lightwhite.yml
+++ b/themes/Gutterslob lightwhite.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Light White
+  name: Gutterslob lightwhite
   author: Gutterslob
   primary:
     background: "#000000"

--- a/themes/Hund.yml
+++ b/themes/Hund.yml
@@ -1,5 +1,5 @@
 colors:
-  name: hund
+  name: Hund
   author: hund
   primary:
     background: "#161616"

--- a/themes/Hybrid.yml
+++ b/themes/Hybrid.yml
@@ -1,28 +1,23 @@
-# Colors (Hybrid)
 colors:
-  # Default colors
   primary:
-    background: '#27292c'
-    foreground: '#d0d2d1'
-
-  # Normal colors
+    background: "#27292c"
+    foreground: "#d0d2d1"
   normal:
-    black:   '#35383b'
-    red:     '#b05655'
-    green:   '#769972'
-    yellow:  '#e1a574'
-    blue:    '#7693ac'
-    magenta: '#977ba0'
-    cyan:    '#749e99'
-    white:   '#848b92'
-
-  # Bright colors
+    black: "#35383b"
+    red: "#b05655"
+    green: "#769972"
+    yellow: "#e1a574"
+    blue: "#7693ac"
+    magenta: "#977ba0"
+    cyan: "#749e99"
+    white: "#848b92"
   bright:
-    black:   '#484c52'
-    red:     '#d27c7b'
-    green:   '#dffebe'
-    yellow:  '#f0d189'
-    blue:    '#96b1c9'
-    magenta: '#bfa5c7'
-    cyan:    '#9fc9c3'
-    white:   '#fcf7e2'
+    black: "#484c52"
+    red: "#d27c7b"
+    green: "#dffebe"
+    yellow: "#f0d189"
+    blue: "#96b1c9"
+    magenta: "#bfa5c7"
+    cyan: "#9fc9c3"
+    white: "#fcf7e2"
+  name: Hybrid

--- a/themes/Hyper.yml
+++ b/themes/Hyper.yml
@@ -1,31 +1,26 @@
-# Colors (Hyper)
 colors:
-  # Default colors
   primary:
-    background: '#000000'
-    foreground: '#ffffff'
+    background: "#000000"
+    foreground: "#ffffff"
   cursor:
-    text: '#F81CE5'
-    cursor: '#ffffff'
-
-  # Normal colors
+    text: "#F81CE5"
+    cursor: "#ffffff"
   normal:
-    black:   '#000000'
-    red:     '#fe0100'
-    green:   '#33ff00'
-    yellow:  '#feff00'
-    blue:    '#0066ff'
-    magenta: '#cc00ff'
-    cyan:    '#00ffff'
-    white:   '#d0d0d0'
-
-  # Bright colors
+    black: "#000000"
+    red: "#fe0100"
+    green: "#33ff00"
+    yellow: "#feff00"
+    blue: "#0066ff"
+    magenta: "#cc00ff"
+    cyan: "#00ffff"
+    white: "#d0d0d0"
   bright:
-    black:   '#808080'
-    red:     '#fe0100'
-    green:   '#33ff00'
-    yellow:  '#feff00'
-    blue:    '#0066ff'
-    magenta: '#cc00ff'
-    cyan:    '#00ffff'
-    white:   '#FFFFFF'
+    black: "#808080"
+    red: "#fe0100"
+    green: "#33ff00"
+    yellow: "#feff00"
+    blue: "#0066ff"
+    magenta: "#cc00ff"
+    cyan: "#00ffff"
+    white: "#FFFFFF"
+  name: Hyper

--- a/themes/IR-Black.yml
+++ b/themes/IR-Black.yml
@@ -1,32 +1,26 @@
-# Colors (IR Black)
 colors:
-  # Default colors
   primary:
-    background: '#000000'
-    foreground: '#ffffff'
-
+    background: "#000000"
+    foreground: "#ffffff"
   cursor:
-    text: '#ffffff'
-    cursor: '#ffffff'
-
-  # Normal colors
+    text: "#ffffff"
+    cursor: "#ffffff"
   normal:
-    black:   '#4e4e4e'
-    red:     '#ff6c60'
-    green:   '#a8ff60'
-    yellow:  '#ffffb6'
-    blue:    '#96cbfe'
-    magenta: '#ff73fd'
-    cyan:    '#c6c5fe'
-    white:   '#eeeeee'
-
-  # Bright colors
+    black: "#4e4e4e"
+    red: "#ff6c60"
+    green: "#a8ff60"
+    yellow: "#ffffb6"
+    blue: "#96cbfe"
+    magenta: "#ff73fd"
+    cyan: "#c6c5fe"
+    white: "#eeeeee"
   bright:
-    black:   '#7c7c7c'
-    red:     '#ffb6b0'
-    green:   '#ceffab'
-    yellow:  '#ffffcb'
-    blue:    '#b5dcfe'
-    magenta: '#ff9cfe'
-    cyan:    '#dfdffe'
-    white:   '#ffffff'
+    black: "#7c7c7c"
+    red: "#ffb6b0"
+    green: "#ceffab"
+    yellow: "#ffffcb"
+    blue: "#b5dcfe"
+    magenta: "#ff9cfe"
+    cyan: "#dfdffe"
+    white: "#ffffff"
+  name: IR-Black

--- a/themes/Iceberg-Dark.yml
+++ b/themes/Iceberg-Dark.yml
@@ -1,28 +1,23 @@
-# Colors (Iceberg Dark)
 colors:
-  # Default colors
   primary:
-    background: '#161821'
-    foreground: '#d2d4de'
-
-  # Normal colors
+    background: "#161821"
+    foreground: "#d2d4de"
   normal:
-    black:   '#161821'
-    red:     '#e27878'
-    green:   '#b4be82'
-    yellow:  '#e2a478'
-    blue:    '#84a0c6'
-    magenta: '#a093c7'
-    cyan:    '#89b8c2'
-    white:   '#c6c8d1'
-
-  # Bright colors
+    black: "#161821"
+    red: "#e27878"
+    green: "#b4be82"
+    yellow: "#e2a478"
+    blue: "#84a0c6"
+    magenta: "#a093c7"
+    cyan: "#89b8c2"
+    white: "#c6c8d1"
   bright:
-    black:   '#6b7089'
-    red:     '#e98989'
-    green:   '#c0ca8e'
-    yellow:  '#e9b189'
-    blue:    '#91acd1'
-    magenta: '#ada0d3'
-    cyan:    '#95c4ce'
-    white:   '#d2d4de'
+    black: "#6b7089"
+    red: "#e98989"
+    green: "#c0ca8e"
+    yellow: "#e9b189"
+    blue: "#91acd1"
+    magenta: "#ada0d3"
+    cyan: "#95c4ce"
+    white: "#d2d4de"
+  name: Iceberg-Dark

--- a/themes/Iceberg-Light.yml
+++ b/themes/Iceberg-Light.yml
@@ -1,28 +1,23 @@
-# Colors (Iceberg Light)
 colors:
-  # Default colors
   primary:
-    background: '0xe8e9ec'
-    foreground: '0x33374c'
-
-  # Normal colors
+    background: "0xe8e9ec"
+    foreground: "0x33374c"
   normal:
-    black:   '0xdcdfe7'
-    red:     '0xcc517a'
-    green:   '0x668e3d'
-    yellow:  '0xc57339'
-    blue:    '0x2d539e'
-    magenta: '0x7759b4'
-    cyan:    '0x3f83a6'
-    white:   '0x33374c'
-
-  # Bright colors
+    black: "0xdcdfe7"
+    red: "0xcc517a"
+    green: "0x668e3d"
+    yellow: "0xc57339"
+    blue: "0x2d539e"
+    magenta: "0x7759b4"
+    cyan: "0x3f83a6"
+    white: "0x33374c"
   bright:
-    black:   '0x8389a3'
-    red:     '0xcc3768'
-    green:   '0x598030'
-    yellow:  '0xb6662d'
-    blue:    '0x22478e'
-    magenta: '0x6845ad'
-    cyan:    '0x327698'
-    white:   '0x262a3f'
+    black: "0x8389a3"
+    red: "0xcc3768"
+    green: "0x598030"
+    yellow: "0xb6662d"
+    blue: "0x22478e"
+    magenta: "0x6845ad"
+    cyan: "0x327698"
+    white: "0x262a3f"
+  name: Iceberg-Light

--- a/themes/Isotope.dark.yml
+++ b/themes/Isotope.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Isotope (dark)
+  name: Isotope.dark
   author: Chris Kempson
   primary:
     background: "#000000"

--- a/themes/Isotope.light.yml
+++ b/themes/Isotope.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Isotope (light)
+  name: Isotope.light
   author: Chris Kempson
   primary:
     background: "#ffffff"

--- a/themes/Jasonwryan.yml
+++ b/themes/Jasonwryan.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Jason Wryan
+  name: Jasonwryan
   author: ""
   primary:
     background: "#000000"

--- a/themes/Jellybeans.yml
+++ b/themes/Jellybeans.yml
@@ -1,38 +1,29 @@
-# Colors (Jellybeans)
 colors:
-  # Default colors
   primary:
-    background: '#161616'
-    foreground: '#e4e4e4'
-
-  # Cursor volors
+    background: "#161616"
+    foreground: "#e4e4e4"
   cursor:
-    text: '#feffff'
-    cursor: '#ffb472'
-
-  # Normal colors
+    text: "#feffff"
+    cursor: "#ffb472"
   normal:
-    black:   '#a3a3a3'
-    red:     '#e98885'
-    green:   '#a3c38b'
-    yellow:  '#ffc68d'
-    blue:    '#a6cae2'
-    magenta: '#e7cdfb'
-    cyan:    '#00a69f'
-    white:   '#e4e4e4'
-
-  # Bright colors
+    black: "#a3a3a3"
+    red: "#e98885"
+    green: "#a3c38b"
+    yellow: "#ffc68d"
+    blue: "#a6cae2"
+    magenta: "#e7cdfb"
+    cyan: "#00a69f"
+    white: "#e4e4e4"
   bright:
-    black:   '#c8c8c8'
-    red:     '#ffb2b0'
-    green:   '#c8e2b9'
-    yellow:  '#ffe1af'
-    blue:    '#bddff7'
-    magenta: '#fce2ff'
-    cyan:    '#0bbdb6'
-    white:   '#feffff'
-
-  # Selection colors
+    black: "#c8c8c8"
+    red: "#ffb2b0"
+    green: "#c8e2b9"
+    yellow: "#ffe1af"
+    blue: "#bddff7"
+    magenta: "#fce2ff"
+    cyan: "#0bbdb6"
+    white: "#feffff"
   selection:
-    text: '#5963a2'
-    background: '#f6f6f6'
+    text: "#5963a2"
+    background: "#f6f6f6"
+  name: Jellybeans

--- a/themes/Jmbi.yml
+++ b/themes/Jmbi.yml
@@ -1,5 +1,5 @@
 colors:
-  name: jmbi
+  name: Jmbi
   author: jmbi
   primary:
     background: "#1e1e1e"

--- a/themes/Jwr-dark.yml
+++ b/themes/Jwr-dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: JWR dark
+  name: Jwr-dark
   author: ""
   primary:
     background: "#000000"

--- a/themes/Kitty.yml
+++ b/themes/Kitty.yml
@@ -1,27 +1,23 @@
 colors:
-  # Default colors
   primary:
-    background: '#000000'
-    foreground: '#dddddd'
-
-  # Normal colors
+    background: "#000000"
+    foreground: "#dddddd"
   normal:
-    black:   '#000000'
-    red:     '#cc0403'
-    green:   '#19cb00'
-    yellow:  '#cecb00'
-    blue:    '#0d73cc'
-    magenta: '#cb1ed1'
-    cyan:    '#0dcdcd'
-    white:   '#dddddd'
-
-  # Bright colors
+    black: "#000000"
+    red: "#cc0403"
+    green: "#19cb00"
+    yellow: "#cecb00"
+    blue: "#0d73cc"
+    magenta: "#cb1ed1"
+    cyan: "#0dcdcd"
+    white: "#dddddd"
   bright:
-    black:   '#767676'
-    red:     '#f2201f'
-    green:   '#23fd00'
-    yellow:  '#fffd00'
-    blue:    '#1a8fff'
-    magenta: '#fd28ff'
-    cyan:    '#14ffff'
-    white:   '#ffffff'
+    black: "#767676"
+    red: "#f2201f"
+    green: "#23fd00"
+    yellow: "#fffd00"
+    blue: "#1a8fff"
+    magenta: "#fd28ff"
+    cyan: "#14ffff"
+    white: "#ffffff"
+  name: Kitty

--- a/themes/Londontube.dark.yml
+++ b/themes/Londontube.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Londontube (dark)
+  name: Londontube.dark
   author: Chris Kempson
   primary:
     background: "#231f20"

--- a/themes/Londontube.light.yml
+++ b/themes/Londontube.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Londontube (light)
+  name: Londontube.light
   author: Chris Kempson
   primary:
     background: "#ffffff"

--- a/themes/Marrakesh.dark.yml
+++ b/themes/Marrakesh.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Marrakesh (dark)
+  name: Marrakesh.dark
   author: Chris Kempson
   primary:
     background: "#201602"

--- a/themes/Marrakesh.light.yml
+++ b/themes/Marrakesh.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Marrakesh (light)
+  name: Marrakesh.light
   author: Chris Kempson
   primary:
     background: "#faf0a5"

--- a/themes/Material-Theme.yml
+++ b/themes/Material-Theme.yml
@@ -1,28 +1,23 @@
-# Colors (Material Theme)
 colors:
-  # Default colors
   primary:
-    background: '#263238'
-    foreground: '#eeffff'
-
-  # Normal colors
+    background: "#263238"
+    foreground: "#eeffff"
   normal:
-    black:   '#000000'  # Arbitrary
-    red:     '#e53935'
-    green:   '#91b859'
-    yellow:  '#ffb62c'
-    blue:    '#6182b8'
-    magenta: '#ff5370'  # Dark pink of the original material theme
-    cyan:    '#39adb5'
-    white:   '#a0a0a0'  # Arbitrary
-
-  # Bright colors
+    black: "#000000"
+    red: "#e53935"
+    green: "#91b859"
+    yellow: "#ffb62c"
+    blue: "#6182b8"
+    magenta: "#ff5370"
+    cyan: "#39adb5"
+    white: "#a0a0a0"
   bright:
-    black:   '#4e4e4e'  # Arbitrary
-    red:     '#ff5370'
-    green:   '#c3e88d'
-    yellow:  '#ffcb6b'
-    blue:    '#82aaff'
-    magenta: '#f07178'  # Pink of the original material theme
-    cyan:    '#89ddff'
-    white:   '#ffffff'  # Arbitrary
+    black: "#4e4e4e"
+    red: "#ff5370"
+    green: "#c3e88d"
+    yellow: "#ffcb6b"
+    blue: "#82aaff"
+    magenta: "#f07178"
+    cyan: "#89ddff"
+    white: "#ffffff"
+  name: Material-Theme

--- a/themes/Mocha.dark.yml
+++ b/themes/Mocha.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Mocha (dark)
+  name: Mocha.dark
   author: Chris Kempson
   primary:
     background: "#3b3228"

--- a/themes/Mocha.light.yml
+++ b/themes/Mocha.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Mocha (light)
+  name: Mocha.light
   author: Chris Kempson
   primary:
     background: "#f5eeeb"

--- a/themes/Molokai.yml
+++ b/themes/Molokai.yml
@@ -1,26 +1,23 @@
-# Colors (Molokai Dark)
 colors:
-  # Default colors
   primary:
-    background: '#1B1D1E'
-    foreground: '#F8F8F2'
-  # Normal colors
+    background: "#1B1D1E"
+    foreground: "#F8F8F2"
   normal:
-    black:   '#333333'
-    red:     '#C4265E'
-    green:   '#86B42B'
-    yellow:  '#B3B42B'
-    blue:    '#6A7EC8'
-    magenta: '#8C6BC8'
-    cyan:    '#56ADBC'
-    white:   '#E3E3DD'
-  # Bright colors
+    black: "#333333"
+    red: "#C4265E"
+    green: "#86B42B"
+    yellow: "#B3B42B"
+    blue: "#6A7EC8"
+    magenta: "#8C6BC8"
+    cyan: "#56ADBC"
+    white: "#E3E3DD"
   bright:
-    black:   '#666666'
-    red:     '#F92672'
-    green:   '#A6E22E'
-    yellow:  '#E2E22E'
-    blue:    '#819AFF'
-    magenta: '#AE81FF'
-    cyan:    '#66D9EF'
-    white:   '#F8F8F2'
+    black: "#666666"
+    red: "#F92672"
+    green: "#A6E22E"
+    yellow: "#E2E22E"
+    blue: "#819AFF"
+    magenta: "#AE81FF"
+    cyan: "#66D9EF"
+    white: "#F8F8F2"
+  name: Molokai

--- a/themes/Monokai-Pro.yml
+++ b/themes/Monokai-Pro.yml
@@ -1,28 +1,23 @@
-# Colors (Monokai Pro)
 colors:
-  # Default colors
   primary:
-    background: '#2D2A2E'
-    foreground: '#FCFCFA'
-
-  # Normal colors
+    background: "#2D2A2E"
+    foreground: "#FCFCFA"
   normal:
-    black:   '#403E41'
-    red:     '#FF6188'
-    green:   '#A9DC76'
-    yellow:  '#FFD866'
-    blue:    '#FC9867'
-    magenta: '#AB9DF2'
-    cyan:    '#78DCE8'
-    white:   '#FCFCFA'
-
-  # Bright colors
+    black: "#403E41"
+    red: "#FF6188"
+    green: "#A9DC76"
+    yellow: "#FFD866"
+    blue: "#FC9867"
+    magenta: "#AB9DF2"
+    cyan: "#78DCE8"
+    white: "#FCFCFA"
   bright:
-    black:   '#727072'
-    red:     '#FF6188'
-    green:   '#A9DC76'
-    yellow:  '#FFD866'
-    blue:    '#FC9867'
-    magenta: '#AB9DF2'
-    cyan:    '#78DCE8'
-    white:   '#FCFCFA'
+    black: "#727072"
+    red: "#FF6188"
+    green: "#A9DC76"
+    yellow: "#FFD866"
+    blue: "#FC9867"
+    magenta: "#AB9DF2"
+    cyan: "#78DCE8"
+    white: "#FCFCFA"
+  name: Monokai-Pro

--- a/themes/Monokai-Soda.yml
+++ b/themes/Monokai-Soda.yml
@@ -1,28 +1,23 @@
-# Colors (Monokai Soda)
 colors:
-  # Default colors
   primary:
-    background: '#1a1a1a'
-    foreground: '#c4c5b5'
-
-  # Normal colors
+    background: "#1a1a1a"
+    foreground: "#c4c5b5"
   normal:
-    black:   '#1a1a1a'
-    red:     '#f4005f'
-    green:   '#98e024'
-    yellow:  '#fa8419'
-    blue:    '#9d65ff'
-    magenta: '#f4005f'
-    cyan:    '#58d1eb'
-    white:   '#c4c5b5'
-
-  # Bright colors
+    black: "#1a1a1a"
+    red: "#f4005f"
+    green: "#98e024"
+    yellow: "#fa8419"
+    blue: "#9d65ff"
+    magenta: "#f4005f"
+    cyan: "#58d1eb"
+    white: "#c4c5b5"
   bright:
-    black:   '#625e4c'
-    red:     '#f4005f'
-    green:   '#98e024'
-    yellow:  '#e0d561'
-    blue:    '#9d65ff'
-    magenta: '#f4005f'
-    cyan:    '#58d1eb'
-    white:   '#f6f6ef'
+    black: "#625e4c"
+    red: "#f4005f"
+    green: "#98e024"
+    yellow: "#e0d561"
+    blue: "#9d65ff"
+    magenta: "#f4005f"
+    cyan: "#58d1eb"
+    white: "#f6f6ef"
+  name: Monokai-Soda

--- a/themes/Monokai.dark.yml
+++ b/themes/Monokai.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Monokai (dark)
+  name: Monokai.dark
   author: Chris Kempson
   primary:
     background: "#272822"

--- a/themes/Monokai.light.yml
+++ b/themes/Monokai.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Monokai (light)
+  name: Monokai.light
   author: Chris Kempson
   primary:
     background: "#f9f8f5"

--- a/themes/Monotheme.yml
+++ b/themes/Monotheme.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Mono Theme
+  name: Monotheme
   author: ""
   primary:
     background: "#000000"

--- a/themes/Mostly-bright.yml
+++ b/themes/Mostly-bright.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Mostly Bright
+  name: Mostly-bright
   author: m83
   primary:
     background: "#F3F3F3"

--- a/themes/Muzieca lowcontrast.yml
+++ b/themes/Muzieca lowcontrast.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Low Contrast
+  name: Muzieca lowcontrast
   author: Muzieca
   primary:
     background: "#3c3b37"

--- a/themes/Muzieca mono.yml
+++ b/themes/Muzieca mono.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Mono
+  name: Muzieca mono
   author: Muzieca
   primary:
     background: "#000000"

--- a/themes/Muzieca pastel white.yml
+++ b/themes/Muzieca pastel white.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Pastel White
+  name: Muzieca pastel white
   author: Muzieca
   primary:
     background: "#000000"

--- a/themes/Navy-and-ivory.yml
+++ b/themes/Navy-and-ivory.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Navy and Ivory
+  name: Navy-and-ivory
   author: hal
   primary:
     background: "#021b21"

--- a/themes/New-Moon.yml
+++ b/themes/New-Moon.yml
@@ -1,26 +1,23 @@
-# Colors (New Moon)
 colors:
-  # Default colors
   primary:
-    background: '#2D2D2D'
-    foreground: '#B3B9C5'
-  # Normal colors
+    background: "#2D2D2D"
+    foreground: "#B3B9C5"
   normal:
-    black: '#2D2D2D'
-    red: '#F2777A'
-    green: '#92D192'
-    yellow: '#FFD479'
-    blue: '#6AB0F3'
-    magenta: '#E1A6F2'
-    cyan: '#76D4D6'
-    white: '#B3B9C5'
-  # Bright colors
+    black: "#2D2D2D"
+    red: "#F2777A"
+    green: "#92D192"
+    yellow: "#FFD479"
+    blue: "#6AB0F3"
+    magenta: "#E1A6F2"
+    cyan: "#76D4D6"
+    white: "#B3B9C5"
   bright:
-    black: '#777C85'
-    red: '#F2777A'
-    green: '#76D4D6'
-    yellow: '#FFEEA6'
-    blue: '#6AB0F3'
-    magenta: '#E1A6F2'
-    cyan: '#76D4D6'
-    white: '#FFFFFF'
+    black: "#777C85"
+    red: "#F2777A"
+    green: "#76D4D6"
+    yellow: "#FFEEA6"
+    blue: "#6AB0F3"
+    magenta: "#E1A6F2"
+    cyan: "#76D4D6"
+    white: "#FFFFFF"
+  name: New-Moon

--- a/themes/Nightfly.yml
+++ b/themes/Nightfly.yml
@@ -1,36 +1,29 @@
-# Colors (Nightfly)
 colors:
-   # Default colors
   primary:
-     background: '#011627'
-     foreground: '#acb4c2'
-
+    background: "#011627"
+    foreground: "#acb4c2"
   cursor:
-    text: '#fafafa'
-    cursor: '#9ca1aa'
-
+    text: "#fafafa"
+    cursor: "#9ca1aa"
   selection:
-    text: '#080808'
-    background: '#b2ceee'
-
-   # Normal colors
+    text: "#080808"
+    background: "#b2ceee"
   normal:
-    black:   '#1d3b53'
-    red:     '#fc514e'
-    green:   '#a1cd5e'
-    yellow:  '#e3d18a'
-    blue:    '#82aaff'
-    magenta: '#c792ea'
-    cyan:    '#7fdbca'
-    white:   '#a1aab8'
-
-   # Bright colors
+    black: "#1d3b53"
+    red: "#fc514e"
+    green: "#a1cd5e"
+    yellow: "#e3d18a"
+    blue: "#82aaff"
+    magenta: "#c792ea"
+    cyan: "#7fdbca"
+    white: "#a1aab8"
   bright:
-    black:   '#7c8f8f'
-    red:     '#ff5874'
-    green:   '#21c7a8'
-    yellow:  '#ecc48d'
-    blue:    '#82aaff'
-    magenta: '#ae81ff'
-    cyan:    '#7fdbca'
-    white:   '#d6deeb'
+    black: "#7c8f8f"
+    red: "#ff5874"
+    green: "#21c7a8"
+    yellow: "#ecc48d"
+    blue: "#82aaff"
+    magenta: "#ae81ff"
+    cyan: "#7fdbca"
+    white: "#d6deeb"
+  name: Nightfly

--- a/themes/Nord.yml
+++ b/themes/Nord.yml
@@ -1,28 +1,23 @@
-# Colors (Nord)
 colors:
-   # Default colors
-   primary:
-     background: '#2E3440'
-     foreground: '#D8DEE9'
-
-   # Normal colors
-   normal:
-     black:   '#3B4252'
-     red:     '#BF616A'
-     green:   '#A3BE8C'
-     yellow:  '#EBCB8B'
-     blue:    '#81A1C1'
-     magenta: '#B48EAD'
-     cyan:    '#88C0D0'
-     white:   '#E5E9F0'
-
-   # Bright colors
-   bright:
-     black:   '#4C566A'
-     red:     '#BF616A'
-     green:   '#A3BE8C'
-     yellow:  '#EBCB8B'
-     blue:    '#81A1C1'
-     magenta: '#B48EAD'
-     cyan:    '#8FBCBB'
-     white:   '#ECEFF4'
+  primary:
+    background: "#2E3440"
+    foreground: "#D8DEE9"
+  normal:
+    black: "#3B4252"
+    red: "#BF616A"
+    green: "#A3BE8C"
+    yellow: "#EBCB8B"
+    blue: "#81A1C1"
+    magenta: "#B48EAD"
+    cyan: "#88C0D0"
+    white: "#E5E9F0"
+  bright:
+    black: "#4C566A"
+    red: "#BF616A"
+    green: "#A3BE8C"
+    yellow: "#EBCB8B"
+    blue: "#81A1C1"
+    magenta: "#B48EAD"
+    cyan: "#8FBCBB"
+    white: "#ECEFF4"
+  name: Nord

--- a/themes/Nova.yml
+++ b/themes/Nova.yml
@@ -1,32 +1,26 @@
-# Colors (Nova)
 colors:
-  # Default colors
   primary:
-    background: '#3C4C55'
-    foreground: '#C5D4DD'
-
+    background: "#3C4C55"
+    foreground: "#C5D4DD"
   cursor:
-    text: '#212121'
-    cursor: '#C0C5CE'
-
-  # Normal colors
+    text: "#212121"
+    cursor: "#C0C5CE"
   normal:
-    black:   '#3C4C55'
-    red:     '#DF8C8C'
-    green:   '#A8CE93'
-    yellow:  '#DADA93'
-    blue:    '#83AFE5'
-    magenta: '#9A93E1'
-    cyan:    '#7FC1CA'
-    white:   '#C5D4DD'
-
-  # Bright colors
+    black: "#3C4C55"
+    red: "#DF8C8C"
+    green: "#A8CE93"
+    yellow: "#DADA93"
+    blue: "#83AFE5"
+    magenta: "#9A93E1"
+    cyan: "#7FC1CA"
+    white: "#C5D4DD"
   bright:
-    black:   '#899BA6'
-    red:     '#F2C38F'
-    green:   '#A8CE93'
-    yellow:  '#DADA93'
-    blue:    '#83AFE5'
-    magenta: '#D18EC2'
-    cyan:    '#7FC1CA'
-    white:   '#E6EEF3'
+    black: "#899BA6"
+    red: "#F2C38F"
+    green: "#A8CE93"
+    yellow: "#DADA93"
+    blue: "#83AFE5"
+    magenta: "#D18EC2"
+    cyan: "#7FC1CA"
+    white: "#E6EEF3"
+  name: Nova

--- a/themes/NumixDarkest.yml
+++ b/themes/NumixDarkest.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Numix Darkest
+  name: NumixDarkest
   author: ""
   primary:
     background: "#282828"

--- a/themes/OK100 - Matrix.yml
+++ b/themes/OK100 - Matrix.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Matrix
+  name: OK100 - Matrix
   author: OK100
   primary:
     background: "#000000"

--- a/themes/Ocean.dark.yml
+++ b/themes/Ocean.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Ocean (dark)
+  name: Ocean.dark
   author: Chris Kempson
   primary:
     background: "#2b303b"

--- a/themes/Ocean.light.yml
+++ b/themes/Ocean.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Ocean (light)
+  name: Ocean.light
   author: Chris Kempson
   primary:
     background: "#eff1f5"

--- a/themes/Oceanic-Next.yml
+++ b/themes/Oceanic-Next.yml
@@ -1,33 +1,26 @@
-# Colors (Oceanic Next)
 colors:
-  # Default colors
   primary:
-    background: '#1b2b34'
-    foreground: '#d8dee9'
-
-  # Colors the cursor will use if `custom_cursor_colors` is true
+    background: "#1b2b34"
+    foreground: "#d8dee9"
   cursor:
-    text: '#1b2b34'
-    cursor: '#ffffff'
-
-  # Normal colors
+    text: "#1b2b34"
+    cursor: "#ffffff"
   normal:
-    black:   '#343d46'
-    red:     '#EC5f67'
-    green:   '#99C794'
-    yellow:  '#FAC863'
-    blue:    '#6699cc'
-    magenta: '#c594c5'
-    cyan:    '#5fb3b3'
-    white:   '#d8dee9'
-
-  # Bright colors
+    black: "#343d46"
+    red: "#EC5f67"
+    green: "#99C794"
+    yellow: "#FAC863"
+    blue: "#6699cc"
+    magenta: "#c594c5"
+    cyan: "#5fb3b3"
+    white: "#d8dee9"
   bright:
-    black:   '#343d46'
-    red:     '#EC5f67'
-    green:   '#99C794'
-    yellow:  '#FAC863'
-    blue:    '#6699cc'
-    magenta: '#c594c5'
-    cyan:    '#5fb3b3'
-    white:   '#d8dee9'
+    black: "#343d46"
+    red: "#EC5f67"
+    green: "#99C794"
+    yellow: "#FAC863"
+    blue: "#6699cc"
+    magenta: "#c594c5"
+    cyan: "#5fb3b3"
+    white: "#d8dee9"
+  name: Oceanic-Next

--- a/themes/One-Dark.yml
+++ b/themes/One-Dark.yml
@@ -1,30 +1,23 @@
-# Colors (One Dark)
 colors:
-  # Default colors
   primary:
-    background: '#282c34'
-    foreground: '#abb2bf'
-
-  # Normal colors
+    background: "#282c34"
+    foreground: "#abb2bf"
   normal:
-    # NOTE: Use '#131613' for the `black` color if you'd like to see
-    # black text on the background.
-    black:   '#282c34'
-    red:     '#e06c75'
-    green:   '#98c379'
-    yellow:  '#d19a66'
-    blue:    '#61afef'
-    magenta: '#c678dd'
-    cyan:    '#56b6c2'
-    white:   '#abb2bf'
-
-  # Bright colors
+    black: "#282c34"
+    red: "#e06c75"
+    green: "#98c379"
+    yellow: "#d19a66"
+    blue: "#61afef"
+    magenta: "#c678dd"
+    cyan: "#56b6c2"
+    white: "#abb2bf"
   bright:
-    black:   '#5c6370'
-    red:     '#e06c75'
-    green:   '#98c379'
-    yellow:  '#d19a66'
-    blue:    '#61afef'
-    magenta: '#c678dd'
-    cyan:    '#56b6c2'
-    white:   '#ffffff'
+    black: "#5c6370"
+    red: "#e06c75"
+    green: "#98c379"
+    yellow: "#d19a66"
+    blue: "#61afef"
+    magenta: "#c678dd"
+    cyan: "#56b6c2"
+    white: "#ffffff"
+  name: One-Dark

--- a/themes/One-Light.yml
+++ b/themes/One-Light.yml
@@ -1,30 +1,23 @@
-# Colors (One Light)
 colors:
-  # Default colors
   primary:
-    foreground: '#282c34'
-    background: '#ffffff'
-
-  # Normal colors
+    foreground: "#282c34"
+    background: "#ffffff"
   normal:
-    # NOTE: Use '#131613' for the `black` color if you'd like to see
-    # black text on the background.
-    black:   '#282c34'
-    red:     '#e06c75'
-    green:   '#98c379'
-    yellow:  '#d19a66'
-    blue:    '#61afef'
-    magenta: '#c678dd'
-    cyan:    '#56b6c2'
-    white:   '#abb2bf'
-
-  # Bright colors
+    black: "#282c34"
+    red: "#e06c75"
+    green: "#98c379"
+    yellow: "#d19a66"
+    blue: "#61afef"
+    magenta: "#c678dd"
+    cyan: "#56b6c2"
+    white: "#abb2bf"
   bright:
-    black:   '#5c6370'
-    red:     '#e06c75'
-    green:   '#98c379'
-    yellow:  '#d19a66'
-    blue:    '#61afef'
-    magenta: '#c678dd'
-    cyan:    '#56b6c2'
-    white:   '#ffffff'
+    black: "#5c6370"
+    red: "#e06c75"
+    green: "#98c379"
+    yellow: "#d19a66"
+    blue: "#61afef"
+    magenta: "#c678dd"
+    cyan: "#56b6c2"
+    white: "#ffffff"
+  name: One-Light

--- a/themes/Oxide.yml
+++ b/themes/Oxide.yml
@@ -1,33 +1,27 @@
-# Colors (Oxide)
 colors:
-  # Default colors
   primary:
-    background: '#212121'
-    foreground: '#c0c5ce'
-    bright_foreground: '#f3f4f5'
-
+    background: "#212121"
+    foreground: "#c0c5ce"
+    bright_foreground: "#f3f4f5"
   cursor:
-    text: '#212121'
-    cursor: '#c0c5ce'
-
-  # Normal colors
+    text: "#212121"
+    cursor: "#c0c5ce"
   normal:
-    black:   '#212121'
-    red:     '#e57373'
-    green:   '#a6bc69'
-    yellow:  '#fac863'
-    blue:    '#6699cc'
-    magenta: '#c594c5'
-    cyan:    '#5fb3b3'
-    white:   '#c0c5ce'
-
-  # Bright colors
+    black: "#212121"
+    red: "#e57373"
+    green: "#a6bc69"
+    yellow: "#fac863"
+    blue: "#6699cc"
+    magenta: "#c594c5"
+    cyan: "#5fb3b3"
+    white: "#c0c5ce"
   bright:
-    black:   '#5c5c5c'
-    red:     '#e57373'
-    green:   '#a6bc69'
-    yellow:  '#fac863'
-    blue:    '#6699cc'
-    magenta: '#c594c5'
-    cyan:    '#5fb3b3'
-    white:   '#f3f4f5'
+    black: "#5c5c5c"
+    red: "#e57373"
+    green: "#a6bc69"
+    yellow: "#fac863"
+    blue: "#6699cc"
+    magenta: "#c594c5"
+    cyan: "#5fb3b3"
+    white: "#f3f4f5"
+  name: Oxide

--- a/themes/Paraiso.dark.yml
+++ b/themes/Paraiso.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Paraiso (dark)
+  name: Paraiso.dark
   author: Chris Kempson
   primary:
     background: "#2f1e2e"

--- a/themes/Paraiso.light.yml
+++ b/themes/Paraiso.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Paraiso (light)
+  name: Paraiso.light
   author: Chris Kempson
   primary:
     background: "#e7e9db"

--- a/themes/Parker_brothers.yml
+++ b/themes/Parker_brothers.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Parker Brothers
+  name: Parker_brothers
   author: ""
   primary:
     background: "#000000"

--- a/themes/Pencil-Dark.yml
+++ b/themes/Pencil-Dark.yml
@@ -1,26 +1,23 @@
-# Colors (Pencil Dark)
 colors:
-  # Default Colors
   primary:
-    background: '#212121'
-    foreground: '#f1f1f1'
-  # Normal colors
+    background: "#212121"
+    foreground: "#f1f1f1"
   normal:
-    black:   '#212121'
-    red:     '#c30771'
-    green:   '#10a778'
-    yellow:  '#a89c14'
-    blue:    '#008ec4'
-    magenta: '#523c79'
-    cyan:    '#20a5ba'
-    white:   '#e0e0e0'
-  # Bright colors
+    black: "#212121"
+    red: "#c30771"
+    green: "#10a778"
+    yellow: "#a89c14"
+    blue: "#008ec4"
+    magenta: "#523c79"
+    cyan: "#20a5ba"
+    white: "#e0e0e0"
   bright:
-    black:   '#212121'
-    red:     '#fb007a'
-    green:   '#5fd7af'
-    yellow:  '#f3e430'
-    blue:    '#20bbfc'
-    magenta: '#6855de'
-    cyan:    '#4fb8cc'
-    white:   '#f1f1f1'
+    black: "#212121"
+    red: "#fb007a"
+    green: "#5fd7af"
+    yellow: "#f3e430"
+    blue: "#20bbfc"
+    magenta: "#6855de"
+    cyan: "#4fb8cc"
+    white: "#f1f1f1"
+  name: Pencil-Dark

--- a/themes/Pencil-Light.yml
+++ b/themes/Pencil-Light.yml
@@ -1,26 +1,23 @@
-# Colors (Pencil Light)
 colors:
-  # Default Colors
   primary:
-    background: '#f1f1f1'
-    foreground: '#424242'
-  # Normal colors
+    background: "#f1f1f1"
+    foreground: "#424242"
   normal:
-    black:   '#212121'
-    red:     '#c30771'
-    green:   '#10a778'
-    yellow:  '#a89c14'
-    blue:    '#008ec4'
-    magenta: '#523c79'
-    cyan:    '#20a5ba'
-    white:   '#e0e0e0'
-  # Bright colors
+    black: "#212121"
+    red: "#c30771"
+    green: "#10a778"
+    yellow: "#a89c14"
+    blue: "#008ec4"
+    magenta: "#523c79"
+    cyan: "#20a5ba"
+    white: "#e0e0e0"
   bright:
-    black:   '#212121'
-    red:     '#fb007a'
-    green:   '#5fd7af'
-    yellow:  '#f3e430'
-    blue:    '#20bbfc'
-    magenta: '#6855de'
-    cyan:    '#4fb8cc'
-    white:   '#f1f1f1'
+    black: "#212121"
+    red: "#fb007a"
+    green: "#5fd7af"
+    yellow: "#f3e430"
+    blue: "#20bbfc"
+    magenta: "#6855de"
+    cyan: "#4fb8cc"
+    white: "#f1f1f1"
+  name: Pencil-Light

--- a/themes/Pop!-OS.yml
+++ b/themes/Pop!-OS.yml
@@ -1,27 +1,23 @@
 colors:
-  # Default colors
   primary:
-    background: '#333333'
-    foreground: '#F2F2F2'
-
-  # Normal colors
+    background: "#333333"
+    foreground: "#F2F2F2"
   normal:
-    black:   '#333333'
-    red:     '#CC0000'
-    green:   '#4E9A06'
-    yellow:  '#C4A000'
-    blue:    '#3465A4'
-    magenta: '#75507B'
-    cyan:    '#06989A'
-    white:   '#D3D7CF'
-
-  # Bright colors
+    black: "#333333"
+    red: "#CC0000"
+    green: "#4E9A06"
+    yellow: "#C4A000"
+    blue: "#3465A4"
+    magenta: "#75507B"
+    cyan: "#06989A"
+    white: "#D3D7CF"
   bright:
-    black:   '#88807C'
-    red:     '#F15D22'
-    green:   '#73C48F'
-    yellow:  '#FFCE51'
-    blue:    '#48B9C7'
-    magenta: '#AD7FA8'
-    cyan:    '#34E2E2'
-    white:   '#EEEEEC'
+    black: "#88807C"
+    red: "#F15D22"
+    green: "#73C48F"
+    yellow: "#FFCE51"
+    blue: "#48B9C7"
+    magenta: "#AD7FA8"
+    cyan: "#34E2E2"
+    white: "#EEEEEC"
+  name: Pop!-OS

--- a/themes/Pretty-and-pastel.yml
+++ b/themes/Pretty-and-pastel.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Pretty and Pastel
+  name: Pretty-and-pastel
   author: IWAFU
   primary:
     background: "#151515"

--- a/themes/Railscasts.dark.yml
+++ b/themes/Railscasts.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Railscasts (dark)
+  name: Railscasts.dark
   author: Chris Kempson
   primary:
     background: "#2b2b2b"

--- a/themes/Railscasts.light.yml
+++ b/themes/Railscasts.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Railscasts (light)
+  name: Railscasts.light
   author: Chris Kempson
   primary:
     background: "#f9f7f3"

--- a/themes/Rooster - SOS.yml
+++ b/themes/Rooster - SOS.yml
@@ -1,5 +1,5 @@
 colors:
-  name: SOS
+  name: Rooster - SOS
   author: Rooster
   primary:
     background: "#373b43"

--- a/themes/S3r0-modified.yml
+++ b/themes/S3r0-modified.yml
@@ -1,5 +1,5 @@
 colors:
-  name: s3r0 modified
+  name: S3r0-modified
   author: earsplit
   primary:
     background: "#1F1F1F"

--- a/themes/Seabird.yml
+++ b/themes/Seabird.yml
@@ -1,28 +1,23 @@
-# Colors (Seagull)
 colors:
-  # Default colors
   primary:
-    background: '#ffffff'
-    foreground: '#61707a'
-
-  # Normal colors
+    background: "#ffffff"
+    foreground: "#61707a"
   normal:
-    black:   '#0b141a'
-    red:     '#ff4053'
-    green:   '#11ab00'
-    yellow:  '#bf8c00'
-    blue:    '#0099ff'
-    magenta: '#9854ff'
-    cyan:    '#00a5ab'
-    white:   '#ffffff'
-
-  # Bright colors
+    black: "#0b141a"
+    red: "#ff4053"
+    green: "#11ab00"
+    yellow: "#bf8c00"
+    blue: "#0099ff"
+    magenta: "#9854ff"
+    cyan: "#00a5ab"
+    white: "#ffffff"
   bright:
-    black:   '#0b141a'
-    red:     '#ff4053'
-    green:   '#11ab00'
-    yellow:  '#bf8c00'
-    blue:    '#0099ff'
-    magenta: '#9854ff'
-    cyan:    '#00a5ab'
-    white:   '#ffffff'
+    black: "#0b141a"
+    red: "#ff4053"
+    green: "#11ab00"
+    yellow: "#bf8c00"
+    blue: "#0099ff"
+    magenta: "#9854ff"
+    cyan: "#00a5ab"
+    white: "#ffffff"
+  name: Seabird

--- a/themes/Seoul256.yml
+++ b/themes/Seoul256.yml
@@ -1,28 +1,23 @@
-# Colors (Seoul256)
 colors:
-  # Default colors
   primary:
-    background: '#3a3a3a'
-    foreground: '#d0d0d0'
-
-  # Normal colors
+    background: "#3a3a3a"
+    foreground: "#d0d0d0"
   normal:
-    black:   '#4e4e4e'
-    red:     '#d68787'
-    green:   '#5f865f'
-    yellow:  '#d8af5f'
-    blue:    '#85add4'
-    magenta: '#d7afaf'
-    cyan:    '#87afaf'
-    white:   '#d0d0d0'
-
-  # Bright colors
+    black: "#4e4e4e"
+    red: "#d68787"
+    green: "#5f865f"
+    yellow: "#d8af5f"
+    blue: "#85add4"
+    magenta: "#d7afaf"
+    cyan: "#87afaf"
+    white: "#d0d0d0"
   bright:
-    black:   '#626262'
-    red:     '#d75f87'
-    green:   '#87af87'
-    yellow:  '#ffd787'
-    blue:    '#add4fb'
-    magenta: '#ffafaf'
-    cyan:    '#87d7d7'
-    white:   '#e4e4e4'
+    black: "#626262"
+    red: "#d75f87"
+    green: "#87af87"
+    yellow: "#ffd787"
+    blue: "#add4fb"
+    magenta: "#ffafaf"
+    cyan: "#87d7d7"
+    white: "#e4e4e4"
+  name: Seoul256

--- a/themes/Sexcolors.yml
+++ b/themes/Sexcolors.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Sex Colors
+  name: Sexcolors
   author: ""
   primary:
     background: "#000000"

--- a/themes/Shapeshifter.dark.yml
+++ b/themes/Shapeshifter.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Shapeshifter (dark)
+  name: Shapeshifter.dark
   author: Chris Kempson
   primary:
     background: "#000000"

--- a/themes/Shapeshifter.light.yml
+++ b/themes/Shapeshifter.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Shapeshifter (light)
+  name: Shapeshifter.light
   author: Chris Kempson
   primary:
     background: "#f9f9f9"

--- a/themes/Simple_rainbow.yml
+++ b/themes/Simple_rainbow.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Simple Rainbow
+  name: Simple_rainbow
   author: ""
   primary:
     background: "#575757"

--- a/themes/Snazzy.yml
+++ b/themes/Snazzy.yml
@@ -1,28 +1,23 @@
-# Colors (Snazzy)
 colors:
-  # Default colors
   primary:
-    background: '#282a36'
-    foreground: '#eff0eb'
-
-  # Normal colors
+    background: "#282a36"
+    foreground: "#eff0eb"
   normal:
-    black:   '#282a36'
-    red:     '#ff5c57'
-    green:   '#5af78e'
-    yellow:  '#f3f99d'
-    blue:    '#57c7ff'
-    magenta: '#ff6ac1'
-    cyan:    '#9aedfe'
-    white:   '#f1f1f0'
-
-  # Bright colors
+    black: "#282a36"
+    red: "#ff5c57"
+    green: "#5af78e"
+    yellow: "#f3f99d"
+    blue: "#57c7ff"
+    magenta: "#ff6ac1"
+    cyan: "#9aedfe"
+    white: "#f1f1f0"
   bright:
-    black:   '#686868'
-    red:     '#ff5c57'
-    green:   '#5af78e'
-    yellow:  '#f3f99d'
-    blue:    '#57c7ff'
-    magenta: '#ff6ac1'
-    cyan:    '#9aedfe'
-    white:   '#f1f1f0'
+    black: "#686868"
+    red: "#ff5c57"
+    green: "#5af78e"
+    yellow: "#f3f99d"
+    blue: "#57c7ff"
+    magenta: "#ff6ac1"
+    cyan: "#9aedfe"
+    white: "#f1f1f0"
+  name: Snazzy

--- a/themes/Solarized-Dark.yml
+++ b/themes/Solarized-Dark.yml
@@ -1,33 +1,26 @@
-# Colors (Solarized Dark)
 colors:
-  # Default colors
   primary:
-    background: '#002b36' # base03
-    foreground: '#839496' # base0
-
-  # Cursor colors
+    background: "#002b36"
+    foreground: "#839496"
   cursor:
-    text:   '#002b36' # base03
-    cursor: '#839496' # base0
-
-  # Normal colors
+    text: "#002b36"
+    cursor: "#839496"
   normal:
-    black:   '#073642' # base02
-    red:     '#dc322f' # red
-    green:   '#859900' # green
-    yellow:  '#b58900' # yellow
-    blue:    '#268bd2' # blue
-    magenta: '#d33682' # magenta
-    cyan:    '#2aa198' # cyan
-    white:   '#eee8d5' # base2
-
-  # Bright colors
+    black: "#073642"
+    red: "#dc322f"
+    green: "#859900"
+    yellow: "#b58900"
+    blue: "#268bd2"
+    magenta: "#d33682"
+    cyan: "#2aa198"
+    white: "#eee8d5"
   bright:
-    black:   '#002b36' # base03
-    red:     '#cb4b16' # orange
-    green:   '#586e75' # base01
-    yellow:  '#657b83' # base00
-    blue:    '#839496' # base0
-    magenta: '#6c71c4' # violet
-    cyan:    '#93a1a1' # base1
-    white:   '#fdf6e3' # base3
+    black: "#002b36"
+    red: "#cb4b16"
+    green: "#586e75"
+    yellow: "#657b83"
+    blue: "#839496"
+    magenta: "#6c71c4"
+    cyan: "#93a1a1"
+    white: "#fdf6e3"
+  name: Solarized-Dark

--- a/themes/Solarized-Light.yml
+++ b/themes/Solarized-Light.yml
@@ -1,33 +1,26 @@
-# Colors (Solarized Light)
 colors:
-  # Default colors
   primary:
-    background: '#fdf6e3' # base3
-    foreground: '#657b83' # base00
-
-  # Cursor colors
+    background: "#fdf6e3"
+    foreground: "#657b83"
   cursor:
-    text:   '#fdf6e3' # base3
-    cursor: '#657b83' # base00
-
-  # Normal colors
+    text: "#fdf6e3"
+    cursor: "#657b83"
   normal:
-    black:   '#073642' # base02
-    red:     '#dc322f' # red
-    green:   '#859900' # green
-    yellow:  '#b58900' # yellow
-    blue:    '#268bd2' # blue
-    magenta: '#d33682' # magenta
-    cyan:    '#2aa198' # cyan
-    white:   '#eee8d5' # base2
-
-  # Bright colors
+    black: "#073642"
+    red: "#dc322f"
+    green: "#859900"
+    yellow: "#b58900"
+    blue: "#268bd2"
+    magenta: "#d33682"
+    cyan: "#2aa198"
+    white: "#eee8d5"
   bright:
-    black:   '#002b36' # base03
-    red:     '#cb4b16' # orange
-    green:   '#586e75' # base01
-    yellow:  '#657b83' # base00
-    blue:    '#839496' # base0
-    magenta: '#6c71c4' # violet
-    cyan:    '#93a1a1' # base1
-    white:   '#fdf6e3' # base3
+    black: "#002b36"
+    red: "#cb4b16"
+    green: "#586e75"
+    yellow: "#657b83"
+    blue: "#839496"
+    magenta: "#6c71c4"
+    cyan: "#93a1a1"
+    white: "#fdf6e3"
+  name: Solarized-Light

--- a/themes/Sourcerer.yml
+++ b/themes/Sourcerer.yml
@@ -1,29 +1,26 @@
-# scorcerer colors
 colors:
   primary:
-    background: '#222222'
-    foreground: '#c2c2b0'
-
+    background: "#222222"
+    foreground: "#c2c2b0"
   cursor:
-    text:   '#c2c2b0'
-    cursor: '#c2c2b0'
-
+    text: "#c2c2b0"
+    cursor: "#c2c2b0"
   normal:
-    black:   '#111111'
-    red:     '#aa4450'
-    green:   '#719611'
-    yellow:  '#cc8800'
-    blue:    '#6688aa'
-    magenta: '#8f6f8f'
-    cyan:    '#528b8b'
-    white:   '#d3d3d3'
-
+    black: "#111111"
+    red: "#aa4450"
+    green: "#719611"
+    yellow: "#cc8800"
+    blue: "#6688aa"
+    magenta: "#8f6f8f"
+    cyan: "#528b8b"
+    white: "#d3d3d3"
   bright:
-    black:   '#181818'
-    red:     '#ff6a6a'
-    green:   '#b1d631'
-    yellow:  '#ff9800'
-    blue:    '#90b0d1'
-    magenta: '#8181a6'
-    cyan:    '#87ceeb'
-    white:   '#c1cdc1'
+    black: "#181818"
+    red: "#ff6a6a"
+    green: "#b1d631"
+    yellow: "#ff9800"
+    blue: "#90b0d1"
+    magenta: "#8181a6"
+    cyan: "#87ceeb"
+    white: "#c1cdc1"
+  name: Sourcerer

--- a/themes/Substrata.yml
+++ b/themes/Substrata.yml
@@ -1,25 +1,23 @@
-# Colors (substrata)
 colors:
   primary:
-    background: '#191c25'
-    foreground: '#b5b4c9'
+    background: "#191c25"
+    foreground: "#b5b4c9"
   normal:
-    black:   '#2e313d'
-    red:     '#cf8164'
-    green:   '#76a065'
-    yellow:  '#ab924c'
-    blue:    '#8296b0'
-    magenta: '#a18daf'
-    cyan:    '#659ea2'
-    white:   '#b5b4c9'
+    black: "#2e313d"
+    red: "#cf8164"
+    green: "#76a065"
+    yellow: "#ab924c"
+    blue: "#8296b0"
+    magenta: "#a18daf"
+    cyan: "#659ea2"
+    white: "#b5b4c9"
   bright:
-    black:   '#5b5f71'
-    red:     '#fe9f7c'
-    green:   '#92c47e'
-    yellow:  '#d2b45f'
-    blue:    '#a0b9d8'
-    magenta: '#c6aed7'
-    cyan:    '#7dc2c7'
-    white:   '#f0ecfe'
-
-
+    black: "#5b5f71"
+    red: "#fe9f7c"
+    green: "#92c47e"
+    yellow: "#d2b45f"
+    blue: "#a0b9d8"
+    magenta: "#c6aed7"
+    cyan: "#7dc2c7"
+    white: "#f0ecfe"
+  name: Substrata

--- a/themes/Sweetlove.yml
+++ b/themes/Sweetlove.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Sweet Love
+  name: Sweetlove
   author: Boroshlawa
   primary:
     background: "#1F1F1F"

--- a/themes/Taerminal.yml
+++ b/themes/Taerminal.yml
@@ -1,31 +1,26 @@
-# Colors (Taerminal)
 colors:
-  # Default colors
   primary:
-    background: '#26282a'
-    foreground: '#f0f0f0'
+    background: "#26282a"
+    foreground: "#f0f0f0"
   cursor:
-    background: '#f0f0f0'
-    foreground: '#26282a'
-
-  # Normal colors
+    background: "#f0f0f0"
+    foreground: "#26282a"
   normal:
-    black:   '#26282a'
-    red:     '#ff8878'
-    green:   '#b4fb73'
-    yellow:  '#fffcb7'
-    blue:    '#8bbce5'
-    magenta: '#ffb2fe'
-    cyan:    '#a2e1f8'
-    white:   '#f1f1f1'
-
-  # Bright colors
+    black: "#26282a"
+    red: "#ff8878"
+    green: "#b4fb73"
+    yellow: "#fffcb7"
+    blue: "#8bbce5"
+    magenta: "#ffb2fe"
+    cyan: "#a2e1f8"
+    white: "#f1f1f1"
   bright:
-    black:   '#6f6f6f'
-    red:     '#fe978b'
-    green:   '#d6fcba'
-    yellow:  '#fffed5'
-    blue:    '#c2e3ff'
-    magenta: '#ffc6ff'
-    cyan:    '#c0e9f8'
-    white:   '#ffffff'
+    black: "#6f6f6f"
+    red: "#fe978b"
+    green: "#d6fcba"
+    yellow: "#fffed5"
+    blue: "#c2e3ff"
+    magenta: "#ffc6ff"
+    cyan: "#c0e9f8"
+    white: "#ffffff"
+  name: Taerminal

--- a/themes/Tango.yml
+++ b/themes/Tango.yml
@@ -1,27 +1,23 @@
-# Colors (Tango)
 colors:
   primary:
-    background: '#000000'
-    foreground: '#00ff00'
-
-  # Normal colors
+    background: "#000000"
+    foreground: "#00ff00"
   normal:
-      black:   '#2e3436'
-      red:     '#cc0000'
-      green:   '#73d216'
-      yellow:  '#edd400'
-      blue:    '#3465a4'
-      magenta: '#75507b'
-      cyan:    '#06989a'
-      white:   '#d3d7cf'
-
-  # Bright colors
+    black: "#2e3436"
+    red: "#cc0000"
+    green: "#73d216"
+    yellow: "#edd400"
+    blue: "#3465a4"
+    magenta: "#75507b"
+    cyan: "#06989a"
+    white: "#d3d7cf"
   bright:
-      black:   '#2e3436'
-      red:     '#ef2929'
-      green:   '#8ae234'
-      yellow:  '#fce94f'
-      blue:    '#729fcf'
-      magenta: '#ad7fa8'
-      cyan:    '#34e2e2'
-      white:   '#eeeeec'
+    black: "#2e3436"
+    red: "#ef2929"
+    green: "#8ae234"
+    yellow: "#fce94f"
+    blue: "#729fcf"
+    magenta: "#ad7fa8"
+    cyan: "#34e2e2"
+    white: "#eeeeec"
+  name: Tango

--- a/themes/Tangoish.yml
+++ b/themes/Tangoish.yml
@@ -1,28 +1,23 @@
-# Colors (Tangoish)
-# Note: Orange is used in place of Cyan
 colors:
   primary:
-    background: '#2e3436'
-    foreground: '#eeeeec'
-
-  # Normal colors
+    background: "#2e3436"
+    foreground: "#eeeeec"
   normal:
-     black:   '#2e3436'
-     red:     '#cc0000'
-     green:   '#73d216'
-     yellow:  '#edd400'
-     blue:    '#3465a4'
-     magenta: '#75507b'
-     cyan:    '#f57900'
-     white:   '#d3d7cf'
-
-  # Bright colors
+    black: "#2e3436"
+    red: "#cc0000"
+    green: "#73d216"
+    yellow: "#edd400"
+    blue: "#3465a4"
+    magenta: "#75507b"
+    cyan: "#f57900"
+    white: "#d3d7cf"
   bright:
-     black:   '#2e3436'
-     red:     '#ef2929'
-     green:   '#8ae234'
-     yellow:  '#fce94f'
-     blue:    '#729fcf'
-     magenta: '#ad7fa8'
-     cyan:    '#fcaf3e'
-     white:   '#eeeeec'
+    black: "#2e3436"
+    red: "#ef2929"
+    green: "#8ae234"
+    yellow: "#fce94f"
+    blue: "#729fcf"
+    magenta: "#ad7fa8"
+    cyan: "#fcaf3e"
+    white: "#eeeeec"
+  name: Tangoish

--- a/themes/Tender.yml
+++ b/themes/Tender.yml
@@ -1,28 +1,23 @@
-# Colors (Tender)
 colors:
-  # Default colors
   primary:
-    background: '#282828'
-    foreground: '#eeeeee'
-
-  # Normal colors
+    background: "#282828"
+    foreground: "#eeeeee"
   normal:
-    black:   '#282828'
-    red:     '#f43753'
-    green:   '#c9d05c'
-    yellow:  '#ffc24b'
-    blue:    '#b3deef'
-    magenta: '#d3b987'
-    cyan:    '#73cef4'
-    white:   '#eeeeee'
-
-  # Bright colors
+    black: "#282828"
+    red: "#f43753"
+    green: "#c9d05c"
+    yellow: "#ffc24b"
+    blue: "#b3deef"
+    magenta: "#d3b987"
+    cyan: "#73cef4"
+    white: "#eeeeee"
   bright:
-    black:   '#4c4c4c'
-    red:     '#f43753'
-    green:   '#c9d05c'
-    yellow:  '#ffc24b'
-    blue:    '#b3deef'
-    magenta: '#d3b987'
-    cyan:    '#73cef4'
-    white:   '#feffff'
+    black: "#4c4c4c"
+    red: "#f43753"
+    green: "#c9d05c"
+    yellow: "#ffc24b"
+    blue: "#b3deef"
+    magenta: "#d3b987"
+    cyan: "#73cef4"
+    white: "#feffff"
+  name: Tender

--- a/themes/Terminal-app-Basic.yml
+++ b/themes/Terminal-app-Basic.yml
@@ -1,23 +1,23 @@
-# Colors (Terminal.app Basic)
 colors:
   primary:
-    background: '#FFFFFF'
-    foreground: '#000000'
+    background: "#FFFFFF"
+    foreground: "#000000"
   normal:
-    black:      '#000000'
-    red:        '#990000'
-    green:      '#00A600'
-    yellow:     '#999900'
-    blue:       '#0000B2'
-    magenta:    '#B200B2'
-    cyan:       '#00A6B2'
-    white:      '#BFBFBF'
+    black: "#000000"
+    red: "#990000"
+    green: "#00A600"
+    yellow: "#999900"
+    blue: "#0000B2"
+    magenta: "#B200B2"
+    cyan: "#00A6B2"
+    white: "#BFBFBF"
   bright:
-    black:      '#666666'
-    red:        '#E50000'
-    green:      '#00D900'
-    yellow:     '#E5E500'
-    blue:       '#0000FF'
-    magenta:    '#E500E5'
-    cyan:       '#00E5E5'
-    white:      '#E5E5E5'
+    black: "#666666"
+    red: "#E50000"
+    green: "#00D900"
+    yellow: "#E5E500"
+    blue: "#0000FF"
+    magenta: "#E500E5"
+    cyan: "#00E5E5"
+    white: "#E5E5E5"
+  name: Terminal-app-Basic

--- a/themes/Terminal-app.yml
+++ b/themes/Terminal-app.yml
@@ -1,28 +1,23 @@
-# Colors (Terminal.app)
 colors:
-  # Default colors
   primary:
-    background: '#000000'
-    foreground: '#b6b6b6'
-
-  # Normal colors
+    background: "#000000"
+    foreground: "#b6b6b6"
   normal:
-    black:   '#000000'
-    red:     '#990000'
-    green:   '#00a600'
-    yellow:  '#999900'
-    blue:    '#0000b2'
-    magenta: '#b200b2'
-    cyan:    '#00a6b2'
-    white:   '#bfbfbf'
-
-  # Bright colors
+    black: "#000000"
+    red: "#990000"
+    green: "#00a600"
+    yellow: "#999900"
+    blue: "#0000b2"
+    magenta: "#b200b2"
+    cyan: "#00a6b2"
+    white: "#bfbfbf"
   bright:
-    black:   '#666666'
-    red:     '#e50000'
-    green:   '#00d900'
-    yellow:  '#e5e500'
-    blue:    '#0000ff'
-    magenta: '#e500e5'
-    cyan:    '#00e5e5'
-    white:   '#e5e5e5'
+    black: "#666666"
+    red: "#e50000"
+    green: "#00d900"
+    yellow: "#e5e500"
+    blue: "#0000ff"
+    magenta: "#e500e5"
+    cyan: "#00e5e5"
+    white: "#e5e5e5"
+  name: Terminal-app

--- a/themes/Theme2.yml
+++ b/themes/Theme2.yml
@@ -1,5 +1,5 @@
 colors:
-  name: theme2
+  name: Theme2
   author: ""
   primary:
     background: "#000000"

--- a/themes/Thwump.yml
+++ b/themes/Thwump.yml
@@ -1,5 +1,5 @@
 colors:
-  name: thwump
+  name: Thwump
   author: ""
   primary:
     background: "#000000"

--- a/themes/Tlh.yml
+++ b/themes/Tlh.yml
@@ -1,5 +1,5 @@
 colors:
-  name: tlh
+  name: Tlh
   author: ""
   primary:
     background: "#101010"

--- a/themes/Tomorrow-Night-Bright.yml
+++ b/themes/Tomorrow-Night-Bright.yml
@@ -1,28 +1,23 @@
-# Colors (Tomorrow Night Bright)
 colors:
-  # Default colors
   primary:
-    background: '#000000'
-    foreground: '#eaeaea'
-
-  # Normal colors
+    background: "#000000"
+    foreground: "#eaeaea"
   normal:
-    black:   '#000000'
-    red:     '#d54e53'
-    green:   '#b9ca4a'
-    yellow:  '#e6c547'
-    blue:    '#7aa6da'
-    magenta: '#c397d8'
-    cyan:    '#70c0ba'
-    white:   '#424242'
-
-  # Bright colors
+    black: "#000000"
+    red: "#d54e53"
+    green: "#b9ca4a"
+    yellow: "#e6c547"
+    blue: "#7aa6da"
+    magenta: "#c397d8"
+    cyan: "#70c0ba"
+    white: "#424242"
   bright:
-    black:   '#666666'
-    red:     '#ff3334'
-    green:   '#9ec400'
-    yellow:  '#e7c547'
-    blue:    '#7aa6da'
-    magenta: '#b77ee0'
-    cyan:    '#54ced6'
-    white:   '#2a2a2a'
+    black: "#666666"
+    red: "#ff3334"
+    green: "#9ec400"
+    yellow: "#e7c547"
+    blue: "#7aa6da"
+    magenta: "#b77ee0"
+    cyan: "#54ced6"
+    white: "#2a2a2a"
+  name: Tomorrow-Night-Bright

--- a/themes/Tomorrow-Night.yml
+++ b/themes/Tomorrow-Night.yml
@@ -1,33 +1,26 @@
-# Colors (Tomorrow Night)
 colors:
-  # Default colors
   primary:
-    background: '#1d1f21'
-    foreground: '#c5c8c6'
-
-  # Colors the cursor will use if `custom_cursor_colors` is true
+    background: "#1d1f21"
+    foreground: "#c5c8c6"
   cursor:
-    text: '#1d1f21'
-    cursor: '#ffffff'
-
-  # Normal colors
+    text: "#1d1f21"
+    cursor: "#ffffff"
   normal:
-    black:   '#1d1f21'
-    red:     '#cc6666'
-    green:   '#b5bd68'
-    yellow:  '#e6c547'
-    blue:    '#81a2be'
-    magenta: '#b294bb'
-    cyan:    '#70c0ba'
-    white:   '#373b41'
-
-  # Bright colors
+    black: "#1d1f21"
+    red: "#cc6666"
+    green: "#b5bd68"
+    yellow: "#e6c547"
+    blue: "#81a2be"
+    magenta: "#b294bb"
+    cyan: "#70c0ba"
+    white: "#373b41"
   bright:
-    black:   '#666666'
-    red:     '#ff3334'
-    green:   '#9ec400'
-    yellow:  '#f0c674'
-    blue:    '#81a2be'
-    magenta: '#b77ee0'
-    cyan:    '#54ced6'
-    white:   '#282a2e'
+    black: "#666666"
+    red: "#ff3334"
+    green: "#9ec400"
+    yellow: "#f0c674"
+    blue: "#81a2be"
+    magenta: "#b77ee0"
+    cyan: "#54ced6"
+    white: "#282a2e"
+  name: Tomorrow-Night

--- a/themes/Tomorrow.dark.yml
+++ b/themes/Tomorrow.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Tomorrow (dark)
+  name: Tomorrow.dark
   author: Chris Kempson
   primary:
     background: "#1d1f21"

--- a/themes/Tomorrow.light.yml
+++ b/themes/Tomorrow.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Tomorrow (light)
+  name: Tomorrow.light
   author: Chris Kempson
   primary:
     background: "#ffffff"

--- a/themes/Trim-yer-beard.yml
+++ b/themes/Trim-yer-beard.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Trim Yer Beard
+  name: Trim-yer-beard
   author: franksn
   primary:
     background: "#191716"

--- a/themes/Twilight.dark.yml
+++ b/themes/Twilight.dark.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Twilight (dark)
+  name: Twilight.dark
   author: Chris Kempson
   primary:
     background: "#1e1e1e"

--- a/themes/Twilight.light.yml
+++ b/themes/Twilight.light.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Twilight (light)
+  name: Twilight.light
   author: Chris Kempson
   primary:
     background: "#ffffff"

--- a/themes/Ubuntu.yml
+++ b/themes/Ubuntu.yml
@@ -1,28 +1,23 @@
-# Colors (Ubuntu)
 colors:
-  # Default colors
   primary:
-    background: '#300a24'
-    foreground: '#eeeeec'
-
-  # Normal colors
+    background: "#300a24"
+    foreground: "#eeeeec"
   normal:
-    black:   '#2e3436'
-    red:     '#cc0000'
-    green:   '#4e9a06'
-    yellow:  '#c4a000'
-    blue:    '#3465a4'
-    magenta: '#75507b'
-    cyan:    '#06989a'
-    white:   '#d3d7cf'
-
-  # Bright colors
+    black: "#2e3436"
+    red: "#cc0000"
+    green: "#4e9a06"
+    yellow: "#c4a000"
+    blue: "#3465a4"
+    magenta: "#75507b"
+    cyan: "#06989a"
+    white: "#d3d7cf"
   bright:
-    black:   '#555753'
-    red:     '#ef2929'
-    green:   '#8ae234'
-    yellow:  '#fce94f'
-    blue:    '#729fcf'
-    magenta: '#ad7fa8'
-    cyan:    '#34e2e2'
-    white:   '#eeeeec'
+    black: "#555753"
+    red: "#ef2929"
+    green: "#8ae234"
+    yellow: "#fce94f"
+    blue: "#729fcf"
+    magenta: "#ad7fa8"
+    cyan: "#34e2e2"
+    white: "#eeeeec"
+  name: Ubuntu

--- a/themes/User 77 - Mashup colors.yml
+++ b/themes/User 77 - Mashup colors.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Mashup Colors
+  name: User 77 - Mashup colors
   author: user 77
   primary:
     background: "#171717"

--- a/themes/Vacuous2.yml
+++ b/themes/Vacuous2.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Vacuous 2
+  name: Vacuous2
   author: hal
   primary:
     background: "#101010"

--- a/themes/Visiblue.yml
+++ b/themes/Visiblue.yml
@@ -1,5 +1,5 @@
 colors:
-  name: VisiBlue
+  name: Visiblue
   author: ""
   primary:
     background: "#000000"

--- a/themes/Visibone-alt-2.yml
+++ b/themes/Visibone-alt-2.yml
@@ -1,5 +1,5 @@
 colors:
-  name: Visibone Alt. 2
+  name: Visibone-alt-2
   author: Gutterslob
   primary:
     background: "#333333"

--- a/themes/Visibone.yml
+++ b/themes/Visibone.yml
@@ -1,5 +1,5 @@
 colors:
-  name: VisiBone
+  name: Visibone
   author: ""
   primary:
     background: "#000000"

--- a/themes/Wombat.yml
+++ b/themes/Wombat.yml
@@ -1,28 +1,23 @@
-# Colors (Wombat)
 colors:
-  # Default colors
   primary:
-    background: '#1f1f1f'
-    foreground: '#e5e1d8'
-
-  # Normal colors
+    background: "#1f1f1f"
+    foreground: "#e5e1d8"
   normal:
-    black:   '#000000'
-    red:     '#f7786d'
-    green:   '#bde97c'
-    yellow:  '#efdfac'
-    blue:    '#6ebaf8'
-    magenta: '#ef88ff'
-    cyan:    '#90fdf8'
-    white:   '#e5e1d8'
-
-  # Bright colors
+    black: "#000000"
+    red: "#f7786d"
+    green: "#bde97c"
+    yellow: "#efdfac"
+    blue: "#6ebaf8"
+    magenta: "#ef88ff"
+    cyan: "#90fdf8"
+    white: "#e5e1d8"
   bright:
-    black:   '#b4b4b4'
-    red:     '#f99f92'
-    green:   '#e3f7a1'
-    yellow:  '#f2e9bf'
-    blue:    '#b3d2ff'
-    magenta: '#e5bdff'
-    cyan:    '#c2fefa'
-    white:   '#ffffff'
+    black: "#b4b4b4"
+    red: "#f99f92"
+    green: "#e3f7a1"
+    yellow: "#f2e9bf"
+    blue: "#b3d2ff"
+    magenta: "#e5bdff"
+    cyan: "#c2fefa"
+    white: "#ffffff"
+  name: Wombat

--- a/themes/X-dotshare.yml
+++ b/themes/X-dotshare.yml
@@ -1,5 +1,5 @@
 colors:
-  name: X::DotShare
+  name: X-dotshare
   author: crshd
   primary:
     background: "#151515"

--- a/themes/X-erosion.yml
+++ b/themes/X-erosion.yml
@@ -1,5 +1,5 @@
 colors:
-  name: X::Erosion
+  name: X-erosion
   author: earsplit
   primary:
     background: "#181512"

--- a/themes/XTerm.yml
+++ b/themes/XTerm.yml
@@ -1,27 +1,23 @@
-# XTerm's default colors
 colors:
-   # Default colors
-   primary:
-     background: '#000000'
-     foreground: '#ffffff'
-   # Normal colors
-   normal:
-     black:   '#000000'
-     red:     '#cd0000'
-     green:   '#00cd00'
-     yellow:  '#cdcd00'
-     blue:    '#0000ee'
-     magenta: '#cd00cd'
-     cyan:    '#00cdcd'
-     white:   '#e5e5e5'
-
-   # Bright colors
-   bright:
-     black:   '#7f7f7f'
-     red:     '#ff0000'
-     green:   '#00ff00'
-     yellow:  '#ffff00'
-     blue:    '#5c5cff'
-     magenta: '#ff00ff'
-     cyan:    '#00ffff'
-     white:   '#ffffff'
+  primary:
+    background: "#000000"
+    foreground: "#ffffff"
+  normal:
+    black: "#000000"
+    red: "#cd0000"
+    green: "#00cd00"
+    yellow: "#cdcd00"
+    blue: "#0000ee"
+    magenta: "#cd00cd"
+    cyan: "#00cdcd"
+    white: "#e5e5e5"
+  bright:
+    black: "#7f7f7f"
+    red: "#ff0000"
+    green: "#00ff00"
+    yellow: "#ffff00"
+    blue: "#5c5cff"
+    magenta: "#ff00ff"
+    cyan: "#00ffff"
+    white: "#ffffff"
+  name: XTerm

--- a/themes/Zenburn.yml
+++ b/themes/Zenburn.yml
@@ -1,5 +1,5 @@
 colors:
-  name: zenburn
+  name: Zenburn
   author: ""
   primary:
     background: "#000000"

--- a/themes/iTerm-Default.yml
+++ b/themes/iTerm-Default.yml
@@ -1,28 +1,23 @@
-# Colors (iTerm 2 default theme)
 colors:
-  # Default colors
   primary:
-    background: '#101421'
-    foreground: '#fffbf6'
-
- # Normal colors
+    background: "#101421"
+    foreground: "#fffbf6"
   normal:
-    black:   '#2e2e2e'
-    red:     '#eb4129'
-    green:   '#abe047'
-    yellow:  '#f6c744'
-    blue:    '#47a0f3'
-    magenta: '#7b5cb0'
-    cyan:    '#64dbed'
-    white:   '#e5e9f0'
-
- # Bright colors
+    black: "#2e2e2e"
+    red: "#eb4129"
+    green: "#abe047"
+    yellow: "#f6c744"
+    blue: "#47a0f3"
+    magenta: "#7b5cb0"
+    cyan: "#64dbed"
+    white: "#e5e9f0"
   bright:
-    black:   '#565656'
-    red:     '#ec5357'
-    green:   '#c0e17d'
-    yellow:  '#f9da6a'
-    blue:    '#49a4f8'
-    magenta: '#a47de9'
-    cyan:    '#99faf2'
-    white:   '#ffffff'
+    black: "#565656"
+    red: "#ec5357"
+    green: "#c0e17d"
+    yellow: "#f9da6a"
+    blue: "#49a4f8"
+    magenta: "#a47de9"
+    cyan: "#99faf2"
+    white: "#ffffff"
+  name: iTerm-Default

--- a/utils.js
+++ b/utils.js
@@ -18,10 +18,25 @@ function getColors(doc) {
   return doc.contents.items.filter((i) => i.key.value === "colors")[0];
 }
 
+// Get theme name from colors
+function getThemeName(doc) {
+  const colors = getColors(doc);
+  const matchingPairs = colors.value.items.filter((i) => i.key.value == "name");
+  if(matchingPairs.length == 0) {
+    return;
+  }
+  const valueScalar = matchingPairs[0].value;
+  if (valueScalar === null) {
+    return;
+  }
+  return valueScalar.value;
+}
+
 module.exports = {
   alacrittyConfigDir: alacrittyConfigDir,
   alacrittyConfigPath: alacrittyConfigPath,
   getThemeYmlPath: getThemeYmlPath,
-  getColors: getColors
+  getColors: getColors,
+  getThemeName: getThemeName
 };
 

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,27 @@
+const path = require("path");
+
+// Alacritty config directory
+const alacrittyConfigDir = (process.env.OS === "Windows_NT")
+  ? path.join(process.env.APPDATA, "alacritty")
+  : path.join(process.env.HOME, ".config/alacritty");
+
+// Alacritty config path
+const alacrittyConfigPath = `${alacrittyConfigDir}/alacritty.yml`;
+
+// Get path to yml for given theme name
+function getThemeYmlPath(theme) {
+  return path.join(__dirname, `themes/${theme}.yml`);
+}
+
+// Find the colors key in yml
+function getColors(doc) {
+  return doc.contents.items.filter((i) => i.key.value === "colors")[0];
+}
+
+module.exports = {
+  alacrittyConfigDir: alacrittyConfigDir,
+  alacrittyConfigPath: alacrittyConfigPath,
+  getThemeYmlPath: getThemeYmlPath,
+  getColors: getColors
+};
+


### PR DESCRIPTION
Related issue: #5

* Refactoring: extracted reusable functions/constants to a common place
* Upgraded inquirer-autocomplete-prompt to v1.2.0 as it had the feature to select a default value
* After applying the theme, save the theme name to `<alacritty-config-dir>/.current-theme`
* Get the current theme name from `<alacritty-config-dir>/.current-theme` file and select it in the prompt by default

<img width="722" alt="Screenshot 2020-10-18 at 1 20 07 AM" src="https://user-images.githubusercontent.com/6568319/96352367-2c7c6280-10e0-11eb-85b4-155e8decf11f.png">

(I have tested these changes in Mac OS only)