### PR TITLE
Change Document Parsing with String(doc) to YAML.stringify(doc)

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function updateTheme(data, theme, preview = false) {
     colors.value = themeColors.value;
   }
 
-  const newContent = String(doc);
+  const newContent = YAML.stringify(doc);
 
   fs.writeFile(ymlPath, newContent, 'utf8', (err) => {
     if (err) throw err;


### PR DESCRIPTION
If there is a duplicate key in the alacritty configuration file, the following error will occur.

````
(alacritty-themes): alacritty-themes
? Select a theme '
❯ 3024.dark
    3024.light
    Afterglow
    Argonaut
    Ashes.dark
    Ashes.light
    Astromouse
    Atelierdune.dark
    Atelierdune.light
  ↓ Atelierforest.dark/Users/xxx/.asdf/installs/nodejs/14.16.0/.npm/lib/node_modules/alacritty-themes/node_modules/yaml/dist/Document -9b4560a1.js:676
    if (this.errors.length > 0) throw new Error('Document with errors cannot be stringified');
                                ^
Error: Document with errors cannot be stringified
    at Document.toString (/Users/xxx/.asdf/installs/nodejs/14.16.0/.npm/lib/node_modules/alacritty-themes/node_modules/yaml/dist/ Document-9b4560a1.js:676:39)
    at String (<anonymous>)
    at updateTheme (/Users/xxx/.asdf/installs/nodejs/14.16.0/.npm/lib/node_modules/alacritty-themes/index.js:91:22)
    at /Users/xxx/.asdf/installs/nodejs/14.16.0/.npm/lib/node_modules/alacritty-themes/index.js:104:5
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:63:3)

  ````

Alacritty.app says that the configuration file is fine, and there are no warnings or error logs, so it's hard to isolate the problem.

I was hoping that alacritty-themes would work the same way as long as the alacritty configuration was working.
In fact, it doesn't, resulting in an error as shown above.
I'm making this PR because I think it's expected to work even with yml in this state.


What do you think about this change idea?
