### PR TITLE
vscode dark+ terminal theme 

### DIFF
--- a/themes/vscode.dark.yml
+++ b/themes/vscode.dark.yml
@@ -1,15 +1,12 @@
 colors:
   name: vscode (dark)
   author: senpai-10
-  
   primary:
     background: "#1E1E1E"
     foreground: "#D4D4D4"
-  
   cursor:
     text: "#1d1f21"
     cursor: "#cccccc"
-  
   normal:
     black: "#000000"
     red: "#cd3131"
@@ -19,7 +16,6 @@ colors:
     magenta: "#bc3fbc"
     cyan: "#11a8cd"
     white: "#e5e5e5"
-
   bright:
     black: "#666666"
     red: "#f14c4c"

--- a/themes/vscode.dark.yml
+++ b/themes/vscode.dark.yml
@@ -1,0 +1,31 @@
+colors:
+  name: vscode (dark)
+  author: senpai-10
+  
+  primary:
+    background: "#1E1E1E"
+    foreground: "#D4D4D4"
+  
+  cursor:
+    text: "#1d1f21"
+    cursor: "#cccccc"
+  
+  normal:
+    black: "#000000"
+    red: "#cd3131"
+    green: "#0dbc79"
+    yellow: "#e5e510"
+    blue: "#2472c8"
+    magenta: "#bc3fbc"
+    cyan: "#11a8cd"
+    white: "#e5e5e5"
+
+  bright:
+    black: "#666666"
+    red: "#f14c4c"
+    green: "#23d18b"
+    yellow: "#f5f543"
+    blue: "#3b8eea"
+    magenta: "#d670d6"
+    cyan: "#29b8db"
+    white: "#e5e5e5"


### PR DESCRIPTION
vscode dark+ theme for alacritty 

![2021-09-04_02-35](https://user-images.githubusercontent.com/53495583/132074376-3814b013-773c-4a06-88d3-a4681aab273c.png)
