### PR TITLE
adding AUR link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ If you are using `npx` you don't have to install the package:
 npx alacritty-themes
 ```
 
+If you are using Archlinux, you can install it from [AUR](https://aur.archlinux.org/packages/alacritty-themes/)
+
+```
+paru -S alacritty-themes
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
archlinux's user repository have a entry for this app
and I'm currently maintaining it https://aur.archlinux.org/packages/alacritty-themes/

If you want know how it was build then please read https://wiki.archlinux.org/title/Node.js_package_guidelines
TLDR, it is totally like npm but wrapping with pacman(archlinux's package manager) for better management through only one system.

Signed-off-by: zoorat <78788887+z00rat@users.noreply.github.com>