### PR TITLE
improve: add argument --current for logging the current theme

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,14 +11,19 @@ const {
   applyTheme,
   createConfigFile,
   getAlacrittyConfig,
+  getCurrentTheme,
 } = require('../index');
 
 const themes = fs.readdirSync(themesFolder()).map((f) => f.replace('.yml', ''));
 
 function main() {
-  if (process.argv.length > 2) {
+  const argumentsExist = process.argv.length > 2;
+
+  if (argumentsExist) {
     if (process.argv.includes('--create') || process.argv.includes('-c')) {
       createConfigFile();
+    } else if (process.argv.includes('--current')) {
+      console.log(getCurrentTheme());
     } else {
       // the 3rd arg is theme name
       applyTheme(process.argv[2]);

--- a/index.js
+++ b/index.js
@@ -44,7 +44,20 @@ function createConfigFile() {
     });
 }
 
-function updateThemeWithFile(data, themePath, ymlPath, preview = false) {
+function getCurrentTheme() {
+  const themeFile = fs.readFileSync(alacrittyConfigPath(), 'utf8');
+  const themeDoc = YAML.parse(themeFile);
+
+  return themeDoc.colors.theme ? themeDoc.colors.theme : 'default';
+}
+
+function updateThemeWithFile(
+  data,
+  themeName,
+  themePath,
+  ymlPath,
+  preview = false
+) {
   const themeFile = fs.readFileSync(themePath, 'utf8');
   const themeDoc = YAML.parseDocument(themeFile);
   const themeColors = themeDoc.contents.items.find(
@@ -65,23 +78,19 @@ function updateThemeWithFile(data, themePath, ymlPath, preview = false) {
     alacrittyDoc.contents.items.push(new Pair('colors', themeColors.value));
   }
 
+  if (alacrittyColors.theme) {
+    alacrittyColors.theme.value = themeName;
+  } else {
+    alacrittyColors.value.items.push(new Pair('theme', themeName));
+  }
+
   const newContent = String(alacrittyDoc);
 
   return fsPromises
     .writeFile(ymlPath, newContent, 'utf8')
     .then(() => {
       if (!preview) {
-        const namePairs = alacrittyColors
-          ? alacrittyColors.value.items.filter((i) => i.key.value === 'name')
-          : [];
-        const themeName = namePairs.length === 0 ? null : namePairs[0].value;
-        if (themeName) {
-          console.log(
-            `The theme "${themeName}" has been applied successfully!`
-          );
-        } else {
-          console.log(`The theme has been applied successfully!`);
-        }
+        console.log(`The theme "${themeName}" has been applied successfully!`);
       }
     })
     .catch((err) => {
@@ -94,7 +103,7 @@ function updateTheme(data, theme, ymlPath, preview = false) {
     fs.existsSync(theme) && !fs.lstatSync(theme).isDirectory();
   const themePath = isSpecificFile ? theme : themeFilePath(theme);
 
-  return updateThemeWithFile(data, themePath, ymlPath, preview);
+  return updateThemeWithFile(data, theme, themePath, ymlPath, preview);
 }
 
 function applyTheme(theme, preview = false) {
@@ -109,4 +118,5 @@ module.exports = {
   applyTheme,
   createConfigFile,
   getAlacrittyConfig,
+  getCurrentTheme,
 };

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function getCurrentTheme() {
   const themeFile = fs.readFileSync(alacrittyConfigPath(), 'utf8');
   const themeDoc = YAML.parse(themeFile);
 
-  return themeDoc.colors.theme ? themeDoc.colors.theme : 'default';
+  return themeDoc.theme ? themeDoc.theme : 'default';
 }
 
 function updateThemeWithFile(
@@ -78,10 +78,14 @@ function updateThemeWithFile(
     alacrittyDoc.contents.items.push(new Pair('colors', themeColors.value));
   }
 
-  if (alacrittyColors.theme) {
-    alacrittyColors.theme.value = themeName;
+  const alacrittyTheme = alacrittyDoc.contents.items.find(
+    (i) => i.key.value === 'theme'
+  );
+
+  if (alacrittyTheme) {
+    alacrittyTheme.value = themeName;
   } else {
-    alacrittyColors.value.items.push(new Pair('theme', themeName));
+    alacrittyDoc.contents.items.push(new Pair('theme', themeName));
   }
 
   const newContent = String(alacrittyDoc);


### PR DESCRIPTION
I added a `--current` argument to get the current theme, which was requested on this issue [How to find out what is the current theme? #25 ](https://github.com/rajasegar/alacritty-themes/issues/25)

I've also changed the message that is logged when selecting a theme to always print the theme.
