### PR TITLE
improve: --help flag and more!

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,7 +28,7 @@ function main() {
       console.log('Options: \n\t--help, -h\tshows this help message and exit');
       console.log('\t--create, -C\tcreates a new config file');
       console.log('\t--current, -c\tshows applied theme name');
-      console.log('\t--list, -l\tlists all avilbale themes');
+      console.log('\t--list, -l\tlists all available themes');
     } else if (
       process.argv.includes('--create') ||
       process.argv.includes('-C')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,9 +20,9 @@ function main() {
   const argumentsExist = process.argv.length > 2;
 
   if (argumentsExist) {
-    if (process.argv.includes('--create') || process.argv.includes('-c')) {
+    if (process.argv.includes('--create') || process.argv.includes('-C')) {
       createConfigFile();
-    } else if (process.argv.includes('--current')) {
+    } else if (process.argv.includes('--current') || process.argv.includes('-c')) {
       console.log(getCurrentTheme());
     } else {
       // the 3rd arg is theme name

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,6 +28,7 @@ function main() {
       console.log('Options: \n\t--help, -h\tshows this help message and exit');
       console.log('\t--create, -C\tcreates a new config file');
       console.log('\t--current, -c\tshows applied theme name');
+      console.log('\t--list, -l\tlists all avilbale themes');
     } else if (
       process.argv.includes('--create') ||
       process.argv.includes('-C')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,7 +27,7 @@ function main() {
       );
       console.log('Options: \n\t--help, -h\tshows this help message and exit');
       console.log('\t--create, -C\tcreates a new config file');
-      console.log('\t--current, -c\tuse provided theme');
+      console.log('\t--current, -c\tshows applied theme name');
     } else if (
       process.argv.includes('--create') ||
       process.argv.includes('-C')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,6 +38,10 @@ function main() {
       process.argv.includes('-c')
     ) {
       console.log(getCurrentTheme());
+    } else if (process.argv.includes('--list') || process.argv.includes('-l')) {
+      themes.map((theme, index) => {
+        console.log(index, theme);
+      });
     } else {
       // the 3rd arg is theme name
       applyTheme(process.argv[2]);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,7 +22,10 @@ function main() {
   if (argumentsExist) {
     if (process.argv.includes('--create') || process.argv.includes('-C')) {
       createConfigFile();
-    } else if (process.argv.includes('--current') || process.argv.includes('-c')) {
+    } else if (
+      process.argv.includes('--current') ||
+      process.argv.includes('-c')
+    ) {
       console.log(getCurrentTheme());
     } else {
       // the 3rd arg is theme name

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,7 +20,12 @@ function main() {
   const argumentsExist = process.argv.length > 2;
 
   if (argumentsExist) {
-    if (process.argv.includes('--create') || process.argv.includes('-C')) {
+    if (process.argv.includes('--help') || process.argv.includes('-h')) {
+      
+    } else if (
+      process.argv.includes('--create') ||
+      process.argv.includes('-C')
+    ) {
       createConfigFile();
     } else if (
       process.argv.includes('--current') ||

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,6 +22,12 @@ function main() {
   if (argumentsExist) {
     if (process.argv.includes('--help') || process.argv.includes('-h')) {
       console.log('Usage: \n\talacritty-themes [options] [theme-name]\n');
+      console.log(
+        'Description: \n\tThemes candy for alacritty A cross-platform GPU-accelerated terminal emulator\n'
+      );
+      console.log('Options: \n\t--help, -h\tshows this help message and exit');
+      console.log('\t--create, -C\tcreates a new config file');
+      console.log('\t--current, -c\tuse provided theme');
     } else if (
       process.argv.includes('--create') ||
       process.argv.includes('-C')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -21,7 +21,7 @@ function main() {
 
   if (argumentsExist) {
     if (process.argv.includes('--help') || process.argv.includes('-h')) {
-      
+      console.log('Usage: \n\talacritty-themes [options] [theme-name]\n');
     } else if (
       process.argv.includes('--create') ||
       process.argv.includes('-C')

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -4,7 +4,8 @@ const settings = require('../../settings');
 
 const NoAlacrittyFileFoundError = new Error(
   'No Alacritty configuration file found.\nExpected one of the following files to exist:\n' +
-    possibleLocations().join('\n') + "\nOr you can create a new one using 'alacritty-themes --create'"
+    possibleLocations().join('\n') +
+    "\nOr you can create a new one using 'alacritty-themes --create'"
 );
 
 function rootDirectory() {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -5,7 +5,7 @@ const settings = require('../../settings');
 const NoAlacrittyFileFoundError = new Error(
   'No Alacritty configuration file found.\nExpected one of the following files to exist:\n' +
     possibleLocations().join('\n') +
-    "\nOr you can create a new one using 'alacritty-themes --create'"
+    '\nOr you can create a new one using `alacritty-themes --create`'
 );
 
 function rootDirectory() {


### PR DESCRIPTION
#70

Adds new flags and, change and add new aliases

[x] `--help` flag alias `-h` print help message
[x] `--list` alias `-l` flag list all themes 
[x] add how to fix NoAlacrittyFileFoundError 

`--help, -l` preview

```
Usage:
	alacritty-themes [options] [theme-name]

Description:
	Themes candy for alacritty A cross-platform GPU-accelerated terminal emulator

Options:
	--help, -h	shows this help message and exit
	--create, -C	creates a new config file
	--current, -c	shows applied theme name
	--list, -l	lists all available themes
```

`--list, -l` preview

```
0 3024.dark
1 3024.light
2 Afterglow
3 Argonaut
4 Ashes.dark
...
```