### PR TITLE
chore(themes) Added Catppuccin and Kanagawa colorschemes

### DIFF
--- a/themes/Catppuccin.yml
+++ b/themes/Catppuccin.yml
@@ -1,0 +1,37 @@
+# Colors (catppuccin)
+colors:
+  # Default colors
+  primary:
+    background: '0x1E1D2F'
+    foreground: '0xD9E0EE'
+
+  cursor:
+    text: '0x1E1D2F'
+    cursor: '0xF5E0DC'
+
+  # Normal colors
+  normal:
+    black:   '0x6E6C7E'
+    red:     '0xF28FAD'
+    green:   '0xABE9B3'
+    yellow:  '0xFAE3B0'
+    blue:    '0x96CDFB'
+    magenta: '0xF5C2E7'
+    cyan:    '0x89DCEB'
+    white:   '0xD9E0EE'
+
+  # Bright colors
+  bright:
+    black:   '0x988BA2'
+    red:     '0xF28FAD'
+    green:   '0xABE9B3'
+    yellow:  '0xFAE3B0'
+    blue:    '0x96CDFB'
+    magenta: '0xF5C2E7'
+    cyan:    '0x89DCEB'
+    white:   '0xD9E0EE'
+
+  indexed_colors:
+    - { index: 16, color: '0xF8BD96' }
+    - { index: 17, color: '0xF5E0DC' }
+

--- a/themes/Kanagawa.yml
+++ b/themes/Kanagawa.yml
@@ -1,0 +1,35 @@
+# Colors (Kanagawa)
+colors:
+  # Default colors
+  primary:
+    background: '0x1f1f28'
+    foreground: '0xdcd7ba'
+
+  # Normal colors
+  normal:
+    black:   '0x090618'
+    red:     '0xc34043'
+    green:   '0x76946a'
+    yellow:  '0xc0a36e'
+    blue:    '0x7e9cd8'
+    magenta: '0x957fb8'
+    cyan:    '0x6a9589'
+    white:   '0xc8c093'
+
+  # Bright colors
+  bright:
+    black:   '0x727169'
+    red:     '0xe82424'
+    green:   '0x98bb6c'
+    yellow:  '0xe6c384'
+    blue:    '0x7fb4ca'
+    magenta: '0x938aa9'
+    cyan:    '0x7aa89f'
+    white:   '0xdcd7ba'
+  selection:
+    background: '0x2d4f67'
+    foreground: '0xc8c093'
+
+  indexed_colors:
+    - { index: 16, color: '0xffa066' }
+    - { index: 17, color: '0xff5d62' }


### PR DESCRIPTION
## I am, by no means, an author of these color schemes. All credits go to the real authors below:

- [**Rebelot**](https://github.com/rebelot) for the [**Kanagawa Color Scheme**](https://github.com/rebelot/kanagawa.nvim/blob/master/extras/alacritty_kanagawa.yml)
- [**Catppuccin Org**](https://github.com/catppuccin) for the [**Catppuccin Color Scheme**](https://github.com/catppuccin/alacritty/blob/main/catppuccin.yml)