### PR TITLE
Add Moonlight II VSCode theme

### DIFF
--- a/themes/Moonlight-II-VSCode.yml
+++ b/themes/Moonlight-II-VSCode.yml
@@ -1,0 +1,28 @@
+colors:
+  primary:
+    background: '0x1e2030'
+    foreground: '0x7f85a3'
+
+  cursor:
+    text:   '0x7f85a3'
+    cursor: '0x808080'
+
+  normal:
+    black:   '0x444a73'
+    red:     '0xff5370'
+    green:   '0x4fd6be'
+    yellow:  '0xffc777'
+    blue:    '0x3e68d7'
+    magenta: '0xfc7b7b'
+    cyan:    '0x86e1fc'
+    white:   '0xd0d0d0'
+
+  bright:
+    black:   '0x828bb8'
+    red:     '0xff98a4'
+    green:   '0xc3e88d'
+    yellow:  '0xffc777'
+    blue:    '0x82aaff'
+    magenta: '0xff966c'
+    cyan:    '0xb4f9f8'
+    white:   '0x5f8787'


### PR DESCRIPTION
Cool theme I bumped into, while trying to make my setup look a little bit more enjoyable.

taken from: https://github.com/eendroroy/alacritty-theme/blob/master/themes/moonlight_ii_vscode.yaml
source: https://github.com/atomiks/moonlight-vscode-theme

![image](https://user-images.githubusercontent.com/11263232/186514509-6107ba9d-170b-4961-8ef7-b6e204c9f639.png)

(don't tell anyone, but I use Arch btw and yes, running in a VM cause I'm too lazy to dual boot as well as too accommodated to leave windows)