### PR TITLE
fix(theme): Dracula Config warning

### DIFF
--- a/themes/Dracula.yml
+++ b/themes/Dracula.yml
@@ -16,7 +16,7 @@ colors:
     focused_match:
       foreground: '#44475a'
       background: '#ffb86c'
-    bar:
+    footer_bar:
       background: '#282a36'
       foreground: '#f8f8f2'
   hints:


### PR DESCRIPTION
bar has been deprecated; use `colors.footer_bar` instead