### PR TITLE
Add Everforest and Rose-Pine dark/light themes

### DIFF
--- a/themes/Everforest_Dark.toml
+++ b/themes/Everforest_Dark.toml
@@ -1,0 +1,28 @@
+# Colors (Everforest Dark)
+
+# Default colors
+[colors.primary]
+background = '#2d353b'
+foreground = '#d3c6aa'
+
+# Normal colors
+[colors.normal]
+black   = '#475258'
+red     = '#e67e80'
+green   = '#a7c080'
+yellow  = '#dbbc7f'
+blue    = '#7fbbb3'
+magenta = '#d699b6'
+cyan    = '#83c092'
+white   = '#d3c6aa'
+
+# Bright colors
+[colors.bright]
+black   = '#475258'
+red     = '#e67e80'
+green   = '#a7c080'
+yellow  = '#dbbc7f'
+blue    = '#7fbbb3'
+magenta = '#d699b6'
+cyan    = '#83c092'
+white   = '#d3c6aa'

--- a/themes/Everforest_Light.toml
+++ b/themes/Everforest_Light.toml
@@ -1,0 +1,28 @@
+# Colors (Everforest Light)
+
+# Default colors
+[colors.primary]
+background = '#fdf6e3'
+foreground = '#5c6a72'
+
+# Normal colors
+[colors.normal]
+black   = '#5c6a72'
+red     = '#f85552'
+green   = '#8da101'
+yellow  = '#dfa000'
+blue    = '#3a94c5'
+magenta = '#df69ba'
+cyan    = '#35a77c'
+white   = '#e0dcc7'
+
+# Bright Colors
+[colors.bright]
+black   = '#5c6a72'
+red     = '#f85552'
+green   = '#8da101'
+yellow  = '#dfa000'
+blue    = '#3a94c5'
+magenta = '#df69ba'
+cyan    = '#35a77c'
+white   = '#e0dcc7'

--- a/themes/Rose-Pine-Dawn.toml
+++ b/themes/Rose-Pine-Dawn.toml
@@ -1,0 +1,39 @@
+[colors.primary]
+background = '#faf4ed'
+foreground = '#575279'
+
+[colors.cursor]
+text = '#575279'
+cursor = '#cecacd'
+
+[colors.vi_mode_cursor]
+text = '#575279'
+cursor = '#cecacd'
+
+[colors.selection]
+text = '#575279'
+background = '#dfdad9'
+
+[colors.normal]
+black = '#f2e9e1'
+red = '#b4637a'
+green = '#286983'
+yellow = '#ea9d34'
+blue = '#56949f'
+magenta = '#907aa9'
+cyan = '#d7827e'
+white = '#575279'
+
+[colors.bright]
+black = '#9893a5'
+red = '#b4637a'
+green = '#286983'
+yellow = '#ea9d34'
+blue = '#56949f'
+magenta = '#907aa9'
+cyan = '#d7827e'
+white = '#575279'
+
+[colors.hints]
+start = { foreground = '#797593', background = '#fffaf3' }
+end = { foreground = '#9893a5', background = '#fffaf3' }

--- a/themes/Rose-Pine-Moon.toml
+++ b/themes/Rose-Pine-Moon.toml
@@ -1,0 +1,38 @@
+[colors.primary]
+background = '#232136'
+foreground = '#e0def4'
+
+[colors.cursor]
+text = '#e0def4'
+cursor = '#56526e'
+
+[colors.vi_mode_cursor]
+text = '#e0def4'
+cursor = '#56526e'
+
+[colors.selection]
+text = '#e0def4'
+background = '#44415a'
+[colors.normal]
+black = '#393552'
+red = '#eb6f92'
+green = '#3e8fb0'
+yellow = '#f6c177'
+blue = '#9ccfd8'
+magenta = '#c4a7e7'
+cyan = '#ea9a97'
+white = '#e0def4'
+
+[colors.bright]
+black = '#6e6a86'
+red = '#eb6f92'
+green = '#3e8fb0'
+yellow = '#f6c177'
+blue = '#9ccfd8'
+magenta = '#c4a7e7'
+cyan = '#ea9a97'
+white = '#e0def4'
+
+[colors.hints]
+start = { foreground = '#908caa', background = '#2a273f' }
+end = { foreground = '#6e6a86', background = '#2a273f' }


### PR DESCRIPTION
This PR add the Everforest and Rose-Pine theme Dark and Light variants

Credits:

- Original Everforest and Rose-Pine theme from (I just copied the .toml files):  https://github.com/alacritty/alacritty-theme
- Everforest theme create by: https://github.com/sainnhe/Everforest
- Rose-Pine theme by: https://github.com/rose-pine

Awesome tool. Thanks to share! :)