### PR TITLE
Add Nord Deep theme

### DIFF
--- a/themes/Nord-Deep.toml
+++ b/themes/Nord-Deep.toml
@@ -1,0 +1,23 @@
+[colors.primary]
+background = "#232731"
+foreground = "#D8DEE9"
+
+[colors.normal]
+black = "#3B4252"
+red = "#BF616A"
+green = "#A3BE8C"
+yellow = "#EBCB8B"
+blue = "#81A1C1"
+magenta = "#B48EAD"
+cyan = "#88C0D0"
+white = "#E5E9F0"
+
+[colors.bright]
+black = "#4C566A"
+red = "#BF616A"
+green = "#A3BE8C"
+yellow = "#EBCB8B"
+blue = "#81A1C1"
+magenta = "#B48EAD"
+cyan = "#8FBCBB"
+white = "#ECEFF4"


### PR DESCRIPTION
It uses the same colorscheme as vscode plugin marlosirapuan.nord-deep
These are the same colors as Nord, with a darker background.